### PR TITLE
master → main, conscious language

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -77,7 +77,7 @@ We are also available on this e-mail: user-cont-team@redhat.com.
   every two weeks. To accomplish this, the release and validation processes are
   completely automated.
 
-- All the tests are passing in CI systems for master branches for all our
+- All the tests are passing in CI systems for the main branches for all our
   projects. No excuses.
 
 - Contributions to packit must be possible by any developer, maintainer,

--- a/content/docs/source-git/_index.md
+++ b/content/docs/source-git/_index.md
@@ -55,7 +55,7 @@ any way you want:
 ### Downstream patches to be applied in the spec file
 
 In the downstream, it's a common workflow to pick up upstream patches from the
-master branch, backport them on top of the current version in Fedora, CentOS
+main branch, backport them on top of the current version in Fedora, CentOS
 Stream or RHEL and apply the patches during the build process.
 
 Source-git is perfect for this because patches are stored as git commits and

--- a/content/docs/source-git/how-to-source-git.md
+++ b/content/docs/source-git/how-to-source-git.md
@@ -41,7 +41,7 @@ $ cd chrony/
 
 At the time of writing this guide:
 * We have chrony 4.0 in Fedora Rawhide
-* 4.0 git tag is also the HEAD of upstream git master (hash:
+* 4.0 git tag is also the HEAD of the main upstream branch (hash:
   d327cfea5a4b5f7385056be8b18f4c5fab01ad13)
 
 In order for us to continue, we need to be able to either generate an archive
@@ -99,10 +99,10 @@ d327cfe (tag: 4.0, origin/master, origin/HEAD, master) nts: save new server keys
 
 ### Downstream patches
 
-It's a common practice to pick up fixes from the master branch of an upstream
-project and backport them to the current (older) version of a package in a
-distribution. Alternatively to accommodate changes specific to the distribution
-which are not merged upstream.
+It's a common practice to pick up fixes from the main upstream branch and
+backport them to the current (older) version of a package in a distribution.
+Alternatively to accommodate changes specific to the distribution which are not
+merged upstream.
 
 In this stage, we are going to apply all downstream patches we have defined in
 our spec file.

--- a/content/docs/source-git/work-with-source-git.md
+++ b/content/docs/source-git/work-with-source-git.md
@@ -137,16 +137,16 @@ Patch1:         drpm-0.3.0-workaround-ppc64le-gcc.patch
 
 The most common workflow in the world of open source development is to accept
 pull requests and have merge commits in the git history. If the PRs are not
-rebased against master before the merge, the history may go wild. Packit is
-able to work with such a state by creating an ephemeral branch with linear
-history and generate the patch files out of it. [More
+rebased against the main branch before the merge, the history may go wild.
+Packit is able to work with such a state by creating an ephemeral branch with
+linear history and generate the patch files out of it. [More
 info](https://github.com/packit/packit/pull/766).
 
 Picking up latest upstream changes into your downstream source-git repo has
 multiple solutions and it's up to you to pick the one which suits your workflow
 best:
 
-1. **Rebase against upstream master branch** (a.k.a. `git pull --rebase
+1. **Rebase against the main upstream branch** (a.k.a. `git pull --rebase
    upstream master`). This solution implies that you are able to perform the
    force-push operation (e.g. Fedora and CentOS dist-git instances don't allow
    force-pushes). Packit will not help you with the rebase process in any way


### PR DESCRIPTION
I could not replace all because we actually have master branches all
over the place (dist-git, our projects).

Context: [Making open source more inclusive by eradicating problematic language ](https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language)