### PR TITLE
Don't run Github actions in forks of this repo

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'packit/packit.dev'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/schedule_link_checker.yml
+++ b/.github/workflows/schedule_link_checker.yml
@@ -5,6 +5,7 @@ on:
     - cron: "0 0 * * 1"
 jobs:
   linkChecker:
+    if: github.repository == 'packit/packit.dev'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Currently, they are run whenever I push to my master and fail because the secret is not configured in my fork.

I could disable Actions in my fork, but this commit should solve the problem for everyone.

https://github.community/t/stop-github-actions-running-on-a-fork/17965