### PR TITLE
Source-git smallish polishing changes

### DIFF
--- a/content/docs/source-git/_index.md
+++ b/content/docs/source-git/_index.md
@@ -61,10 +61,18 @@ to produce a SRPM.
 
 ### Downstream patch generation process
 
-Packit iterates over every git commit sitting on top off [`upstream_ref`]({{<
-ref "configuration.md#upstream_ref" >}}). `upstream_ref` is a border between
-upstream commits, usually matching an upstream release tag, and downstream
-commits.
+The important part of the patch generation process is for Packit to know, from
+which commit it should start generating patches. The theory here is that you
+mark a certain commit and it should resemble the content of the archive. All
+the code changes on top are treated as downstream changes and the respective
+patch files are generated. The marked commit usually represents a specific
+upstream release. This means that all the generated patches need to be able to
+be applied during the build process.
+
+[`upstream_ref`]({{<ref "configuration.md#upstream_ref" >}})
+is this border between upstream commits,
+usually matching an upstream release tag, and downstream commits.
+Packit iterates over every git commit sitting on top off `upstream_ref`.
 
 Packit distinguishes between 2 types of git commits:
 1. Those that change code (usually pulled from upstream) - Packit converts
@@ -81,15 +89,6 @@ Stream or RHEL and apply the patches during the build process.
 
 Source-git is perfect for this because patches are stored as git commits and
 patch files are generated on the fly.
-
-The important part of the patch generation process is for Packit to know, from
-which commit it should start generating patches. The theory here is that you
-mark a certain commit and it should resemble the content of the archive. All
-the code changes on top are treated as downstream changes and the respective
-patch files are generated. The marked commit usually represents a specific
-upstream release. This means that all the generated patches need to be able to
-be applied during the build process.
-
 
 This was just a gentle intro to source-git, for more info you can continue with:
 * [How to create a source-git repo?]({{< ref "/docs/source-git/how-to-source-git.md" >}})

--- a/content/docs/source-git/work-with-source-git/build-locally.md
+++ b/content/docs/source-git/work-with-source-git/build-locally.md
@@ -15,21 +15,18 @@ We are going to use Packit to achieve such a thing, so please make sure you have
 [installed locally](/docs/guide/#have-packit-tooling-installed-locally).
 
 The command to create source RPMs is called `srpm` and that's how you can create one:
-```
-$ packit srpm
-SRPM: /home/tt/g/systemd/systemd-stable/systemd-247.1-2.g68d22b32.fc33.src.rpm
-```
+
+    $ packit srpm
+    SRPM: /home/tt/g/systemd/systemd-stable/systemd-247.1-2.g68d22b32.fc33.src.rpm
 
 Our changes worked! We can try building them, either in our local environment
 using Packit - this implies that all build dependencies are installed:
-```
-$ packit local-build
-```
+
+    $ packit local-build
 
 ...or in [mock](https://github.com/rpm-software-management/mock):
-```
-mock --rebuild -r fedora-rawhide-x86_64 ./systemd-247.1-2.g68d22b32.fc33.src.rpm
-```
+
+    mock --rebuild -r fedora-rawhide-x86_64 ./systemd-247.1-2.g68d22b32.fc33.src.rpm
 
 `-r` allows you [to pick a chroot]({{< ref "configuration.md#available-copr-build-targets" >}})
 of your choice and these are exactly the same which you can specify for builds

--- a/content/docs/source-git/work-with-source-git/propose-to-dist-git.md
+++ b/content/docs/source-git/work-with-source-git/propose-to-dist-git.md
@@ -10,15 +10,13 @@ weight: 3
 Once your changes are merged into a source-git repo, the final step is to
 propose those changes to dist-git and get a production build.
 
-For both, we have a CLI command in Packit which are meant to be run from the
+For both, we have CLI commands in Packit which are meant to be run from the
 source-git's repo checkout.
 
 
 ### Propose...
 
-```
-$ packit propose-downstream --dist-git-branch main
-```
+    $ packit propose-downstream --dist-git-branch main
 
 The command above will take content of your source-git repository and creates a
 pull request for the matching dist-git repo (and dist-git's branch) with the
@@ -34,7 +32,5 @@ welcome to merge and celebrate for doing an update using source-git.
 You can either check out the dist-git repository yourself and perform `fedpkg
 build` as you're used to doing or run the following command from the same
 terminal session:
-```
-$ packit build --dist-git-branch main
-```
 
+    $ packit build --dist-git-branch main

--- a/content/docs/source-git/work-with-source-git/pull-upstream-fixes.md
+++ b/content/docs/source-git/work-with-source-git/pull-upstream-fixes.md
@@ -29,12 +29,11 @@ configure the whole process.
 As an example, let's try to do this with systemd, in the example below we'd be
 using https://gitlab.com/packit-service/src/systemd. The remote mimics how
 `fedpkg fork` works.
-```
-$ git remote -v
-origin      git@gitlab.com:packit-service/src/systemd.git (push)
-ttomecek    git@gitlab.com:TomasTomecek/systemd-stable.git (push)
-upstream    git@github.com:systemd/systemd-stable.git (push)
-```
+
+    $ git remote -v
+    origin      git@gitlab.com:packit-service/src/systemd.git (push)
+    ttomecek    git@gitlab.com:TomasTomecek/systemd-stable.git (push)
+    upstream    git@github.com:systemd/systemd-stable.git (push)
 
 We have 3 remotes in the repo:
 1. `origin` — the official source-git repo where the downstream maintenance happens


### PR DESCRIPTION
The first sentence of "Downstream patch generation process" talks about `upstream_ref` like we already knew what it is.

Then the last paragraph of "Downstream patches to be applied in the spec file" talks about it as well (IIUIC), but this time explains it.

So I'd suggest moving that paragraph ('The important part of the patch generation ...') to the beginning of the "Downstream patch generation process".