### PR TITLE
Update cli docs

### DIFF
--- a/content/docs/CLI/_index.md
+++ b/content/docs/CLI/_index.md
@@ -15,9 +15,15 @@ follow [our guide](/docs/guide/#have-packit-tooling-installed-locally).
 ## Commands
 
 * [build](/docs/cli/build/)
-* [create-bodhi-update](/docs/cli/create-bodhi-update/)
-* [propose-update](/docs/cli/propose-update/)
-* [srpm](/docs/cli/srpm/)
-* [sync-from-downstream](/docs/cli/sync-from-downstream/)
 * [copr-build](/docs/cli/copr-build/)
+* [create-bodhi-update](/docs/cli/create-bodhi-update/)
 * [init](/docs/cli/init/)
+* [local-build](/docs/cli/local-build/)
+* [propose-downstream](/docs/cli/propose-downstream/)
+* [push-updates](/docs/cli/push-updates)
+* [srpm](/docs/cli/srpm/)
+* [status](/docs/cli/status)
+* [sync-from-downstream](/docs/cli/sync-from-downstream/)
+* [validate-config](/docs/cli/validate-config)
+
+

--- a/content/docs/CLI/build.md
+++ b/content/docs/CLI/build.md
@@ -33,16 +33,28 @@ Submit a koji build for the selected branch in Fedora dist-git.
     
       Build selected upstream project in Fedora.
     
-      Packit goes to dist-git and performs `fedpkg build` for the selected
-      branch.
+      By default, packit checks out the respective dist-git repository and
+      performs `fedpkg build` for the selected branch. With `--from-upstream`,
+      packit creates a SRPM out of the current checkout and sends it to koji.
     
       PATH_OR_URL argument is a local path or a URL to the upstream git
       repository, it defaults to the current working directory
     
     Options:
-      --dist-git-branch TEXT  Target branch in dist-git to release into.
+      --dist-git-branch TEXT  Comma separated list of target branches in dist-git
+                              to release into. (defaults to repo's default branch)
+    
       --dist-git-path TEXT    Path to dist-git repo to work in. Otherwise clone
                               the repo in a temporary directory.
+    
+      --from-upstream         Build the project in koji directly from the upstream
+                              repository
+    
+      --koji-target TEXT      Koji target to build inside (see `koji list-
+                              targets`).
+    
       --scratch               Submit a scratch koji build
+      --nowait                Don't wait on build
       -h, --help              Show this message and exit.
+
 

--- a/content/docs/CLI/copr-build.md
+++ b/content/docs/CLI/copr-build.md
@@ -30,10 +30,46 @@ Submit a [Copr](https://copr.fedorainfracloud.org) build of the present content 
     
       Build selected upstream project in COPR.
     
-      PATH_OR_URL argument is a local path or a URL to the upstream git repository, it defaults to the current working directory.
+      PATH_OR_URL argument is a local path or a URL to the upstream git
+      repository, it defaults to the current working directory.
     
     Options:
-      --nowait        Don't wait for build
-      --owner TEXT    Copr user, owner of the project. (defaults to username from ~/.config/copr)
-      --project TEXT  Project name to build in. Will be created if does not exist. (defaults to 'packit-cli-{repo_name}-{branch/commit}')
-      --targets TEXT  Comma separated list of chroots to build in. (defaults to 'fedora-rawhide-x86_64')
+      --nowait                   Don't wait for build
+      --owner TEXT               Copr user, owner of the project. (defaults to
+                                 username from copr config)
+    
+      --project TEXT             Project name to build in. Will be created if does
+                                 not exist. (defaults to the first found project
+                                 value in the config file or 'packit-
+                                 cli-{repo_name}-{branch/commit}')
+    
+      --targets TEXT             Comma separated list of chroots to build in.
+                                 (defaults to 'fedora-rawhide-x86_64')
+    
+      --description TEXT         Description of the project to build in.
+      --instructions TEXT        Installation instructions for the project to
+                                 build in.
+    
+      --list-on-homepage         Created copr project will be visible on copr's
+                                 home-page.
+    
+      --preserve-project         Created copr project will not be removed after 60
+                                 days.
+    
+      --additional-repos TEXT    URLs to additional yum repos, which can be used
+                                 during build. Comma separated. This should be
+                                 baseurl from .repo file. E.g.: http://copr-be.clo
+                                 ud.fedoraproject.org/results/rhughes/f20-gnome-3-
+                                 12/fedora-$releasever-$basearch/
+    
+      --upstream-ref TEXT        Git ref of the last upstream commit in the
+                                 current branch from which packit should generate
+                                 patches (this option implies the repository is
+                                 source-git).
+    
+      --request-admin-if-needed  Ask for admin permissions when we need to change
+                                 settings of the copr project and are not allowed
+                                 to do so.
+    
+      -h, --help                 Show this message and exit.
+

--- a/content/docs/CLI/create-bodhi-update.md
+++ b/content/docs/CLI/create-bodhi-update.md
@@ -42,9 +42,13 @@ Create a new bodhi update for the latest Fedora build of the upstream project.
       repository, it defaults to the current working directory
     
     Options:
-      --dist-git-branch TEXT          Target branch in dist-git to release into.
+      --dist-git-branch TEXT          Comma separated list of target branches in
+                                      dist-git to create bodhi update in.
+                                      (defaults to repo's default branch)
+    
       --koji-build TEXT               Koji build (NVR) to add to the bodhi update
                                       (can be specified multiple times)
+    
       --update-notes TEXT             Bodhi update notes
       --update-type [security|bugfix|enhancement|newpackage]
                                       Type of the bodhi update

--- a/content/docs/CLI/init.md
+++ b/content/docs/CLI/init.md
@@ -104,12 +104,14 @@ If you want to learn more about working with source-git repos, there is a
                               Stream package; implies creating a source-git repo
     
       --dist-git-branch TEXT  Get spec file from this downstream branch, for
-                              Fedora this defaults to master, for CentOS it's c8s.
+                              Fedora this defaults to main, for CentOS it's c8s.
                               When --dist-git-path is set, the default is the
                               branch which is already checked out.
     
       --dist-git-path TEXT    Path to the dist-git repo to use. If this is
                               defined, --fedora-package and --centos-package are
                               ignored.
+    
+      -h, --help              Show this message and exit.
     
       -h, --help              Show this message and exit.

--- a/content/docs/CLI/local-build.md
+++ b/content/docs/CLI/local-build.md
@@ -1,0 +1,27 @@
+---
+title: "Local Build"
+date: 2021-03-18T08:52:33+01:00
+draft: false
+---
+
+# local-build
+
+Create RPMs using content of the upstream repository.
+
+
+## Help
+
+    Usage: packit local-build [OPTIONS] [PATH_OR_URL]
+    
+      Create RPMs using content of the upstream repository.
+    
+      PATH_OR_URL argument is a local path or a URL to the upstream git
+      repository, it defaults to the current working directory
+    
+    Options:
+      --upstream-ref TEXT  Git ref of the last upstream commit in the current
+                           branch from which packit should generate patches (this
+                           option implies the repository is source-git).
+    
+      -h, --help           Show this message and exit.
+

--- a/content/docs/CLI/propose-downstream.md
+++ b/content/docs/CLI/propose-downstream.md
@@ -1,5 +1,5 @@
 ---
-title: "propose-update"
+title: "propose-downstream"
 date: 2019-06-28
 draft: false
 disableToc: false
@@ -45,14 +45,14 @@ upstream release.
   release before copying files downstream.
 
 * Once you have performed the upstream release (and the new archive is up),
-  run `packit propose-update` in a working directory of your upstream
+  run `packit propose-downstream` in a working directory of your upstream
   repository:
   ```
   $ git clone https://github.com/user-cont/colin.git
 
   $ cd colin
 
-  $ packit propose-update
+  $ packit propose-downstream
   using "master" dist-git branch
   syncing ./colin.spec
   INFO: Downloading file from URL https://files.pythonhosted.org/packages/source/c/colin/colin-0.3.0.tar.gz
@@ -62,7 +62,7 @@ upstream release.
   PR created: https://src.fedoraproject.org/rpms/colin/pull-request/4
   ```
 
-  As you can see, one of the things `propose-update` does is, it downloads the
+  As you can see, one of the things `propose-downstream` does is, it downloads the
   upstream release tarball and uploads it to the lookaside cache. [This is
   required by the Fedora Packaging
   Guidelines](https://fedoraproject.org/wiki/Packaging:SourceURL#Referencing_Source).
@@ -72,9 +72,9 @@ upstream release.
 
 ## Help
 
-    Usage: packit propose-update [OPTIONS] [PATH_OR_URL] [VERSION]
+    Usage: packit propose-downstream [OPTIONS] [PATH_OR_URL] [VERSION]
     
-      Release current upstream release into Fedora
+      Land a new upstream release in Fedora.
     
       PATH_OR_URL argument is a local path or a URL to the upstream git
       repository, it defaults to the current working directory
@@ -84,22 +84,20 @@ upstream release.
     
     Options:
       --dist-git-branch TEXT  Comma separated list of target branches in dist-git
-                              to release into. (defaults to 'master')
+                              to release into. (defaults to repo's default branch)
     
       --dist-git-path TEXT    Path to dist-git repo to work in. Otherwise clone
                               the repo in a temporary directory.
     
       --local-content         Do not checkout release tag. Use the current state
-                              of the repo.
+                              of the repo. This option is set by default for
+                              source-git repos
     
       --force-new-sources     Upload the new sources also when the archive is
                               already in the lookaside cache.
     
       --no-pr                 Do not create a pull request to downstream
                               repository.
-    
-      --remote TEXT           Name of the remote to discover upstream project URL,
-                              If this is not specified, default to origin.
     
       --upstream-ref TEXT     Git ref of the last upstream commit in the current
                               branch from which packit should generate patches

--- a/content/docs/CLI/push-updates.md
+++ b/content/docs/CLI/push-updates.md
@@ -1,0 +1,22 @@
+---
+title: "Push Updates"
+date: 2021-03-18T08:52:56+01:00
+draft: false
+---
+
+# push-updates
+
+Push the Bodhi updates that have been in testing for more than 'Stable days' (7 by default)
+to the stable.
+
+
+## Help
+
+    Usage: packit push-updates [OPTIONS] [PATH_OR_URL]
+    
+      Find all Bodhi updates that have been in testing for more than 'Stable
+      days' (7 by default) and push them to stable.
+    
+    Options:
+      --update-alias TEXT  For example FEDORA-2019-ee5674e22c
+      -h, --help           Show this message and exit.

--- a/content/docs/CLI/srpm.md
+++ b/content/docs/CLI/srpm.md
@@ -76,11 +76,10 @@ current_version_command: ["python3", "setup.py", "--version"]
     
     Options:
       --output FILE        Write the SRPM to FILE instead of current dir.
-      --remote TEXT        Name of the remote to discover upstream project URL, If
-                           this is not specified, default to origin.
       --upstream-ref TEXT  Git ref of the last upstream commit in the current
                            branch from which packit should generate patches (this
                            option implies the repository is source-git).
+    
       -h, --help           Show this message and exit.
 
 

--- a/content/docs/CLI/status.md
+++ b/content/docs/CLI/status.md
@@ -1,0 +1,29 @@
+---
+title: "Status"
+date: 2021-03-18T08:53:12+01:00
+draft: false
+---
+
+# status
+
+This command displays latest information related to the project - downstream 
+pull requests, upstream releases, builds in Koji and Copr and updates in Bodhi.
+
+
+## Help
+
+    Usage: packit status [OPTIONS] [PATH_OR_URL]
+    
+      Display status.
+    
+      - latest downstream pull requests
+      - versions from all downstream branches
+      - latest upstream releases
+      - latest builds in Koji
+      - latest builds in Copr
+      - latest updates in Bodhi
+    
+    Options:
+      -h, --help  Show this message and exit.
+
+

--- a/content/docs/CLI/sync-from-downstream.md
+++ b/content/docs/CLI/sync-from-downstream.md
@@ -61,11 +61,21 @@ PR created: https://api.github.com/repos/phracek/colin/pulls/3
       repository, it defaults to the current working directory
     
     Options:
-      --dist-git-branch TEXT  Source branch in dist-git for sync.
-      --upstream-branch TEXT  Target branch in upstream to sync to.
-      --no-pr                 Pull request is not create.
-      --fork / --no-fork      Push to a fork.
-      --remote-name TEXT      Name of the remote where packit should push. if this
-                              is not specified, it pushes to a fork if the repo
-                              can be forked.
+      --dist-git-branch TEXT  Comma separated list of target branches in dist-git
+                              to sync from. (defaults to repo's default branch)
+    
+      --upstream-branch TEXT  Target branch in upstream to sync to. (defaults to
+                              repo's default branch)
+    
+      --no-pr                 Do not create a pull request to upstream repository.
+      --fork / --no-fork      Push to a fork before creating a pull request.
+      --remote-to-push TEXT   Name of the remote where packit should push. If this
+                              is not specified, push to a fork if the repo can be
+                              forked.
+    
+      -f, --force             Don't discard changes in the git repo by default,
+                              unless this is set.
+    
+      -x, --exclude TEXT      File to exclude from sync
       -h, --help              Show this message and exit.
+

--- a/content/docs/CLI/validate-config.md
+++ b/content/docs/CLI/validate-config.md
@@ -1,0 +1,24 @@
+---
+title: "Validate Config"
+date: 2021-03-18T08:48:36+01:00
+draft: false
+---
+# validate-config
+
+Validate the Packit configuration file.
+
+
+## Help
+
+    Usage: packit validate-config [OPTIONS] [PATH_OR_URL]
+    
+      Validate PackageConfig validation.
+    
+      - checks missing values
+      - checks incorrect types
+    
+      PATH_OR_URL argument is a local path or a URL to a git repository with
+      packit configuration file
+    
+    Options:
+      -h, --help  Show this message and exit.

--- a/content/docs/configuration.md
+++ b/content/docs/configuration.md
@@ -454,21 +454,6 @@ Optional metadata:
 * **scratch** -- defaults to `false`, use to create scratch (test) builds
   instead of the real production builds
 
-**sync\_from\_downstream**
-
-Pick up a change (mass rebuild, proven packager rebuild or a fix) from Fedora
-dist-git and send it to upstream repository.
-
-Supported triggers: **commit**.
-
-**Example**
-
-```yaml
-jobs:
-- job: sync_from_downstream
-  trigger: commit
-```
-
 **propose_downstream**
 
 Land a new upstream release in Fedora. This job only makes sure the changes


### PR DESCRIPTION
Initially, I just wanted to remove the docs regarding `sync_from_downstream` job, since currently it is not possible to be configured by users and update the help section for that command, but I found out we have the help sections in CLI docs pretty outdated (it would be nice if we would sync it automatically), so I updated it and added short descriptions to the rest of undocumented commands.