### PR TITLE
Fix paths in curl commands.

### DIFF
--- a/content/docs/source-git/how-to-source-git.md
+++ b/content/docs/source-git/how-to-source-git.md
@@ -71,19 +71,24 @@ pick our spec file from [rawhide](https://src.fedoraproject.org/rpms/chrony/tree
 
     $ mkdir fedora/
     $ cd fedora/
-    $ curl -O https://src.fedoraproject.org/rpms/chrony/raw/master/f/chrony.spec
+    $ curl -O https://src.fedoraproject.org/rpms/chrony/raw/rawhide/f/chrony.spec
 
 As we inspect the spec file, we can see there is an additional source,
 `chrony.dhclient`, which we also need to fetch in order to be able to build
 chrony.
 
-    $ curl -O https://src.fedoraproject.org/rpms/chrony/raw/master/f/chrony.dhclient
+    $ curl -O https://src.fedoraproject.org/rpms/chrony/raw/rawhide/f/chrony.dhclient
 
 Let's commit our changes:
 
     $ cd ../
     $ git add .
     $ git commit -m "Fedora downstream packaging"
+
+    [fedora-rawhide 934818b] Fedora downstream packaging
+     2 files changed, 663 insertions(+)
+     create mode 100644 fedora/chrony.dhclient
+     create mode 100644 fedora/chrony.spec
 
 How does our git history look now?
 
@@ -103,7 +108,7 @@ our spec file.
 
 Right now there is only a single patch chrony has in rawhide, let's apply it:
 
-    $ curl -O https://src.fedoraproject.org/rpms/chrony/raw/master/f/chrony-nm-dispatcher-dhcp.patch
+    $ curl -O https://src.fedoraproject.org/rpms/chrony/raw/main/f/chrony-nm-dispatcher-dhcp.patch
     $ git am chrony-nm-dispatcher-dhcp.patch
     Applying: examples/nm-dispatcher.dhcp: use sysconfig, detect dhclient
 


### PR DESCRIPTION
The curl commands as they were yielded HTML pages that said

    Page not found (404)

    With the message:

    Branch not found

    You have either entered a bad URL or the page has moved, removed, or otherwise rendered unavailable.
    Please use the main navigation menu to get (re)started.

The updated curl commands reflect the correct URLs; with the new curl
commands, it is possible to follow the example to completion.

Signed-off-by: Ben Crocker <bcrocker@redhat.com>