### PR TITLE
synced_files: document the new schema fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 
 public/
+resources/


### PR DESCRIPTION
These were introduced by packit/packit#1211 and packit/packit#1228.

Also: move the examples to be displayed right next to the description,
and refactor them for better readability.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>