### PR TITLE
Add documentation for patch_generation_patch_id_digits

### DIFF
--- a/content/docs/configuration.md
+++ b/content/docs/configuration.md
@@ -226,6 +226,14 @@ You can use following tags in string:
 it excludes changes to the spec file and packit.yaml by default: with this
 option you can precisely specify paths to exclude.
 
+#### patch_generation_patch_id_digits
+
+(*integer*) The number of digits (minimum width) used for patch IDs when
+adding `PatchN` tags to a spec-file while updating dist-git from a source-git
+repository.  Defaults to 4, that is, patches will look like `PatchNNNN:
+<patch_name>`, and leading zeros are added, if needed. A value of 0 means "no
+minimum width".
+
 #### notifications
 
 There is only one notification configuration you can set up right now: enable


### PR DESCRIPTION
And also update the "Create source-git repo" guide to use this field.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>