### PR TITLE
Update docs: `packit init` now sets specfile path in config file

### DIFF
--- a/content/docs/CLI/init.md
+++ b/content/docs/CLI/init.md
@@ -9,7 +9,10 @@ weight: 3
 
 Initiate a repository to start using packit. By default this command adds
 `.packit.yaml` config file to the git repository in the current working
-directory.
+directory.  
+If a spec file is found in the git repository, `init` will set
+[specfile_path](/docs/configuration/#specfile_path) to point to it in `.packit.yaml`.
+Otherwise, `specfile_path` is set to `<the name of the repository>.spec`.
 
 See [`source-git init`]({{< ref "docs/cli/source-git/init" >}}) if you want to
 initialize a [source-git repo]({{< ref "/docs/source-git" >}}).


### PR DESCRIPTION
Update documentation for changes which I implemented [here](https://github.com/packit/packit/pull/1313).
Closes [#1028](https://github.com/packit/packit/issues/1028)