### PR TITLE
CLI/source-git/init: update after the CLI overhaul

### DIFF
--- a/content/docs/CLI/build.md
+++ b/content/docs/CLI/build.md
@@ -5,7 +5,7 @@ disableToc: false
 weight: 3
 ---
 
-# build
+# `packit build`
 
 Submit a koji build for the selected branch in Fedora dist-git.
 

--- a/content/docs/CLI/copr-build.md
+++ b/content/docs/CLI/copr-build.md
@@ -5,7 +5,7 @@ draft: false
 weight: 35
 ---
 
-# copr-build
+# `packit copr-build`
 
 Submit a [Copr](https://copr.fedorainfracloud.org) build of the present content in the upstream repository.
 

--- a/content/docs/CLI/create-bodhi-update.md
+++ b/content/docs/CLI/create-bodhi-update.md
@@ -6,7 +6,7 @@ disableToc: false
 weight: 5
 ---
 
-# create-bodhi-update
+# `packit create-bodhi-update`
 
 Create a new bodhi update for the latest Fedora build of the upstream project.
 

--- a/content/docs/CLI/init.md
+++ b/content/docs/CLI/init.md
@@ -5,7 +5,7 @@ disableToc: false
 weight: 3
 ---
 
-# init
+# `packit init`
 
 Initiate a repository to start using packit. By default this command adds
 `.packit.yaml` config file to the git repository in the current working

--- a/content/docs/CLI/local-build.md
+++ b/content/docs/CLI/local-build.md
@@ -5,7 +5,7 @@ draft: false
 weight: 25
 ---
 
-# local-build
+# `packit local-build`
 
 Create RPMs using content of the upstream repository.
 

--- a/content/docs/CLI/propose-downstream.md
+++ b/content/docs/CLI/propose-downstream.md
@@ -6,7 +6,7 @@ disableToc: false
 weight: 7
 ---
 
-# propose-downstream
+# `packit propose-downstream`
 
 This is a detailed documentation for the update functionality of packit. The
 command creates a new pull request in Fedora using a selected or latest

--- a/content/docs/CLI/push-updates.md
+++ b/content/docs/CLI/push-updates.md
@@ -5,7 +5,7 @@ draft: false
 weight: 20
 ---
 
-# push-updates
+# `packit push-updates`
 
 Push the Bodhi updates that have been in testing for more than 'Stable days' (7 by default)
 to the stable.

--- a/content/docs/CLI/source-git/update-dist-git.md
+++ b/content/docs/CLI/source-git/update-dist-git.md
@@ -5,7 +5,7 @@ weight: 5
 
 ---
 
-# source-git update-dist-git
+# `packit source-git update-dist-git`
 
 Transform the content from a source-git repository in a dist-git format, and
 update the corresponding dist-git repository.

--- a/content/docs/CLI/srpm.md
+++ b/content/docs/CLI/srpm.md
@@ -6,7 +6,7 @@ disableToc: false
 weight: 8
 ---
 
-# srpm
+# `packit srpm`
 
 Create a SRPM of the present content in the upstream repository.
 

--- a/content/docs/CLI/status.md
+++ b/content/docs/CLI/status.md
@@ -5,7 +5,7 @@ draft: false
 weight: 15
 ---
 
-# status
+# `packit status`
 
 This command displays latest information related to the project - downstream
 pull requests, upstream releases, builds in Koji and Copr and updates in Bodhi.

--- a/content/docs/CLI/sync-from-downstream.md
+++ b/content/docs/CLI/sync-from-downstream.md
@@ -6,7 +6,7 @@ disableToc: false
 weight: 9
 ---
 
-# sync-from-downstream
+# `packit sync-from-downstream`
 
 This is a detailed documentation for the downstream sync functionality of packit. The
 command creates a new pull request in upstream repository using a

--- a/content/docs/CLI/validate-config.md
+++ b/content/docs/CLI/validate-config.md
@@ -4,7 +4,7 @@ date: 2021-03-18T08:48:36+01:00
 draft: false
 weight: 30
 ---
-# validate-config
+# `packit validate-config`
 
 Validate the Packit configuration file.
 

--- a/content/docs/source-git/how-to-source-git.md
+++ b/content/docs/source-git/how-to-source-git.md
@@ -10,10 +10,11 @@ weight: 2
 This guide walks through the steps to create a source-git repository from an
 upstream project.
 
-Please bear in mind, that the structure of source-git repositories is still
-being discussed and in development. Due to this, this guide is subject to
-change. Consider joining the [Fedora Source-git SIG] if you are interested and
-would like to participate in the discussions.
+> We have a dedicated command which automates most of the steps described below:
+> [`packit source-git init`]({{< ref "/docs/CLI/source-git/init.md" >}})
+
+Consider joining the [Fedora Source-git SIG] if you are interested in the
+development of the source-git workflow.
 
 The process to construct a source-git repository and a branch to track
 downstream (distribution) work, which then can be synced to dist-git has the


### PR DESCRIPTION
also:
```
how-to-source-git: link to init command

and since the format is no longer so unstable, let's remove that part
```

Fixes #322