### PR TITLE
Document changes about `/packit rebuild-failed` and `retest-failed`

### DIFF
--- a/content/docs/packit-service.md
+++ b/content/docs/packit-service.md
@@ -90,6 +90,16 @@ for the particular check:
 
 ![Re-run Github check](/github-check-rerun.png)
 
+Or it is possible to re-trigger every failed task using a pull request comment
+
+    /packit rebuild-failed
+
+which builds only failed builds and similar for testing farm
+
+    /packit retest-failed
+
+to re-trigger every failed test.
+
 ## How to propose a new downstream update?
 
 Packit Service is able to propose updates of new upstream releases using this comment in an issue:

--- a/content/docs/testing-farm.md
+++ b/content/docs/testing-farm.md
@@ -76,6 +76,11 @@ issues for example), you can use the following comment in the pull request:
 
     /packit test
 
+Or if you want to re-trigger only failed tests, you can use the following comment
+in the pull request:
+
+    /packit retest-failed
+
 ## Creating Tests
 
 The easiest way to get started is to use the [tmt][tmt] tool


### PR DESCRIPTION
Merge after [packit/packit-service#1303](https://github.com/packit/packit-service/pull/1303)