### PR TITLE
Update source-git documentation

### DIFF
--- a/content/docs/CLI/source-git/init.md
+++ b/content/docs/CLI/source-git/init.md
@@ -71,32 +71,35 @@ It will be the base of your source-git repository.
 
     $ packit source-git init --help
     Usage: packit source-git init [OPTIONS] UPSTREAM_REF SOURCE_GIT DIST_GIT
-    
+
       Initialize SOURCE_GIT as a source-git repo by applying downstream patches
       from DIST_GIT as Git commits on top of UPSTREAM_REF.
-    
+
       SOURCE_GIT needs to be an existing clone of the upstream repository.
-    
+
       UPSTREAM_REF is a tag, branch or commit from SOURCE_GIT.
-    
+
       SOURCE_GIT and DIST_GIT are paths to the source-git and dist-git repos.
       Branch names can be specified, separated by colons.
-    
+
       If a branch name is specified for SOURCE_GIT, the branch is checked out and
       reset to UPSTREAM_REF.
-    
+
       If a branch name is specified for DIST_GIT, the branch is checked out before
       setting up the source-git repo. This branch is expected to exist.
-    
+
+      Each Git commit created in SOURCE_GIT will have a 'From-dist-git-commit'
+      trailer to mark the hash of the dist-git commit from which it is created.
+
       To learn more about source-git, please check
-    
+
           https://packit.dev/docs/source-git/
-    
+
       Examples:
-    
+
           $ packit source-git init v2.3.1 src/acl:rawhide rpms/acl:rawhide
           $ packit source-git init --pkg-tool centpkg v2.3.1 src/acl rpms/acl
-    
+
     Options:
       --upstream-url TEXT         Git URL of the upstream repository. It is saved
                                   in the source-git configuration if it is
@@ -116,5 +119,3 @@ It will be the base of your source-git repository.
                                   %prep section of specfile. By default,
                                   %autosetup is required.
       -h, --help                  Show this message and exit.
-
-

--- a/content/docs/CLI/source-git/update-dist-git.md
+++ b/content/docs/CLI/source-git/update-dist-git.md
@@ -12,7 +12,7 @@ update the corresponding dist-git repository.
 ## Help
 
     $ packit source-git update-dist-git --help
-    Usage: packit-dev source-git update-dist-git [OPTIONS] SOURCE_GIT DIST_GIT
+    Usage: packit source-git update-dist-git [OPTIONS] SOURCE_GIT DIST_GIT
 
       Update a dist-git repository using content from a source-git repository
 
@@ -24,7 +24,9 @@ update the corresponding dist-git repository.
       checkout branches or fetches remotes.
 
       A commit in dist-git is created only if a commit message is provided with
-      --message or --file.
+      --message or --file. This commit will have a 'From-source-git-commit' Git-
+      trailer appended to it, to mark the hash of the source-git commit from which
+      it is created.
 
       The source archives are retrieved from the upstream URLs specified in the
       spec-file and uploaded to the lookaside cache in dist-git only if '--pkg-
@@ -35,15 +37,13 @@ update the corresponding dist-git repository.
       To update a dist-git repo from source-git without uploading the source-
       archive to the lookaside cache and creating a commit with the updates, run:
 
-          $ packit -c src/curl/.distro/source-git.yaml source-git update-dist-git \
-                  src/curl rpms/curl
+          $ packit source-git update-dist-git src/curl rpms/curl
 
       To also commit the changes and upload the source-archive to the lookaside-
       cache specify -m and --pkg-tool:
 
-          $ packit -c src/curl/.distro/source-git.yaml source-git update-dist-git \
-                  -m'Update from source-git' --pkg-tool fedpkg \
-                  src/curl rpms/curl
+          $ packit source-git update-dist-git -m'Update from source-git' \
+                  --pkg-tool fedpkg src/curl rpms/curl
 
     Options:
       --upstream-ref TEXT  Git ref of the last upstream commit in the current
@@ -51,12 +51,12 @@ update the corresponding dist-git repository.
                            option implies the repository is source-git).
       --pkg-tool TEXT      Name or path of the packaging tool used to work with
                            sources in the dist-git repo. A variant of 'rpkg'.
-
+                           
                            Skip retrieving and uploading source archives to the
                            lookaside cache if not specified.
       -m, --message <msg>  Commit the changes in the dist-git repository and use
                            <msg> as the commit message.
-
+                           
                            Mutually exclusive with -F.
       -F, --file <file>    Commit the changes in the dist-git repository and take
                            the commit message from <file>. Use - to read from the

--- a/content/docs/CLI/source-git/update-source-git.md
+++ b/content/docs/CLI/source-git/update-source-git.md
@@ -1,0 +1,65 @@
+---
+title: update-source-git
+weight: 6
+
+---
+
+# `packit source-git update-source-git`
+
+Sync changes made in a dist-git repository back to the corresponding
+source-git repository.
+
+This is to enable engineers and bots to capture and sync back changes done
+in dist-git (by provenpackagers during rebuilds, for example). This is why
+changes to the source and patches are not supported! If a package has a
+source-git repository set up, the expectation is that the bulk of the
+packaging work is going to happen there.
+
+## Help
+
+    $ packit source-git update-source-git --help
+    Usage: packit source-git update-source-git [OPTIONS] DIST_GIT SOURCE_GIT
+                                                   REVISION_RANGE
+
+      Update a source-git repository based on a dist-git repository.
+
+      Update a source-git repository with the selected checkout of a spec file and
+      additional packaging files from a dist-git repository.
+
+      Revision range represents part of dist-git history which is supposed to be
+      synchronized. Use `HEAD~..` if you want to synchronize the last commit from
+      dist-git. For more information on possible revision range formats, see
+      gitrevisions(7).
+
+      If patches or the sources file in the spec file changed, the command exits
+      with return code 2. Such changes are not supported by this command, code
+      changes should happen in the source-git repo.
+
+      Inapplicable changes to the .gitignore file are ignored since the file may
+      not be synchronized between dist-git and source-git.
+
+      This command, by default, performs only local operations and uses the
+      content of the source-git and dist-git repositories as it is, no checkout or
+      fetch is performed.
+
+      After the synchronization is done, packit will inform about the changes it
+      has performed and about differences between source-git and dist-git prior to
+      the synchronization process.
+
+      Dist-git commit messages are preserved and used when creating new source-git
+      commits, but a 'From-dist-git-commit' trailer is appended to them to mark
+      the hash of the dist-git commit from which they are created.
+
+      Examples
+
+      Take the last commit (HEAD) of systemd dist-git repo and copy the spec file
+      and other packaging files into the source-git repo:
+
+          $ packit source-git update-source-git rpms/systemd src/systemd HEAD~..
+
+      Synchronize changes from the last three dist-git commits:
+
+          $ packit source-git update-source-git rpms/systemd src/systemd HEAD~3..
+
+    Options:
+      -h, --help  Show this message and exit.

--- a/content/docs/source-git/how-to-source-git.md
+++ b/content/docs/source-git/how-to-source-git.md
@@ -285,6 +285,10 @@ message, and used to tweak how patch-files are generated and included in the
 spec-file. You can include the patch status with the help of the `Patch-status`
 field, and specify the patch-file name with `Patch-name`.
 
+One more Git-trailer that should be added in this step is
+`From-dist-git-commit`, which can be used later on to tell which dist-git
+commit was used to create this source-git repository.
+
 Amend the last commit...
 
     $ git commit --amend
@@ -300,6 +304,7 @@ not be accessible by other users.
 Patch-name: 0001-acl-2.2.53-test-runwrapper.patch
 Patch-status: |-
     avoid permission denied problem with LD_PRELOAD in the test-suite
+From-dist-git-commit: 08c7e74d0a58c9483d2f4f55a3fba2baffb09c3a
 
 # Please enter the commit message for your changes. Lines starting
 # with '#' will be ignored, and an empty message aborts the commit.

--- a/content/docs/source-git/work-with-source-git/sync-from-dist-git.md
+++ b/content/docs/source-git/work-with-source-git/sync-from-dist-git.md
@@ -1,0 +1,28 @@
+---
+title: "Sync back changes made in dist-git"
+date: 2022-02-22
+weight: 6
+---
+
+# Sync back changes made in dist-git
+
+Although we recommend for all packaging work to be done in source-git once it
+was decided to adopt the source-git workflow, some changes are going to keep
+happening in dist-git, like the bumping of release numbers by
+[provenpackagers](https://docs.fedoraproject.org/en-US/fesco/Provenpackager_policy/)
+during re-builds.
+
+In order to prevent the content of the source-git repository from diverging
+from dist-git, these changes need to be synced back to source-git.
+
+Use the `packit source-git update-source-git` command to do this:
+
+    $ packit source-git update-source-git <DIST_GIT_REPO_PATH> <SOURCE_GIT_REPO_PATH> <RANGE>
+
+The command works offline, so it's up to the developer to inspect and push the
+changes synced back to source-git (or open an MR).
+
+The command above will refuse to update the source-git repository, if any of
+the dist-git commits in `<RANGE>` changed the source of the package or any of
+the patch-files. We expect such changes to be done in source-git, or if they
+need to happen in dist-git, to be synced back manually.


### PR DESCRIPTION
- Add missing docs for `update-source-git`.
- Update docs for the other commands and mention the trailers to mark
  the origin of the commits created by the source-git commands.

Related to packit/packit#1488.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>