### PR TITLE
Recreate Contact section and add requirements for Packit Service jobs

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -67,8 +67,11 @@ and create [Bodhi](https://bodhi.fedoraproject.org) updates! [Learn more.](/docs
 4. _We are here to help_ - In case of questions, feel free to contact
    [us](https://github.com/orgs/packit/teams/the-packit-team):
 
-   - **#packit** on [Libera.Chat](https://libera.chat/)
-   - **hello@packit.dev**
+#### Contact
+
+- **#packit:fedora.im** on [Matrix](https://matrix.org/)
+- **#packit** on [Libera.Chat](https://libera.chat/)
+- **hello@packit.dev**
 
 {{< button relref="/docs/guide" >}}Get started{{< /button >}}
 

--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -15,10 +15,10 @@ For each installation we create a new issue in our
 [allowlist tracker](https://github.com/packit/notifications/issues/)
 to resolve this.
 Just be aware that we are now onboarding Fedora contributors who have
-a valid [Fedora Account System](https://fedoraproject.org/wiki/Account_System) account
-and have signed [FPCA](https://fedoraproject.org/wiki/Legal:Fedora_Project_Contributor_Agreement).
+a valid [Fedora Account System](https://fedoraproject.org/wiki/Account_System) account.
 So provide us enough information (your FAS account) in the issue.
 Until that, you will get a neutral status with `Namespace is not allowed!` message on your commits.
+You can find more info about requirements to run Packit Service jobs [here](/docs/packit-service#requirements-for-running-packit-service-jobs).
 
 ## Can I use packit service for any GitHub repository?
 

--- a/content/docs/packit-service.md
+++ b/content/docs/packit-service.md
@@ -29,6 +29,21 @@ in all current Fedora OS releases via [Testing Farm](/docs/testing-farm).
 Packit is also available as a [CLI tool](https://github.com/packit/packit/blob/main/README.md),
 so you can always try things locally on your own. Note that testing is not currently supported with the CLI tool.
 
+
+## Requirements for running Packit Service jobs
+
+As a first step, you need to have a valid [Fedora Account System](https://fedoraproject.org/wiki/Account_System) account to be approved by us and start using Packit Service.
+Besides that:
+* If you want to configure builds via Packit Service, your software needs to comply with [Copr guidelines](https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr) 
+ since we use Fedora Copr for the builds. Therefore, please, make sure you read them before configuring the [Packit Service build job](/docs/configuration/#copr_build).
+* If you are interested in using [internal instance of the Testing Farm](https://docs.testing-farm.io/general/0.1/services.html#_red_hat_ranch)
+to run your tests in, please, [reach out to us](/#contact), since for this job, an additional approval on our side is needed.
+* For retrying the build and test jobs via `/packit build` and `/packit test` pull request comments, you need to have write access to the repository or be the 
+author of the pull request.
+* Similarly, for retrying the propose downstream job via `/packit propose-downstream` issue comment, you need to have write access to
+the repository.
+
+
 ## Integrating Packit-as-a-Service into your project or organization from GitHub Marketplace
 
 1. Navigate to the ["Packit-as-a-Service" GitHub
@@ -74,13 +89,13 @@ or the shorter version
 So whenever you run into a flake or feel like you want to retrigger, just type
 that comment into the PR and enjoy some fine, fresh builds.
 
-The standard requirements for permissions still apply, so if you see this
+The requirements stated in the [previous section](#requirements-for-running-packit-service-jobs) apply, so if you see this
 message
 
     Only users with write or admin permissions to the repository can trigger
     Packit-as-a-Service
 
-it means the author of the pull request does not have commit access to the
+it means the author of the pull request does not have write access to the
 repository so the build cannot be scheduled. This is a perfect case for
 maintainers of the repository to post `/packit build` in the PR to get a build.
 


### PR DESCRIPTION
Fixes #436 

The contact section is linked from more places, so I added it back as a subsection and it looks like this: 
![Snímka obrazovky z 2022-04-25 13-11-34](https://user-images.githubusercontent.com/49026743/165078479-9c8a4985-8063-4d5e-803b-9b51822d67d6.png)

The FPCA requirement is dropped and requirements are summarised in a separate section in Packit Service documentation.

