### PR TITLE
content/docs/faq.md: Use %autorelease instead of deprecated %autorel

### DIFF
--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -155,14 +155,14 @@ Before you start, please make sure that you follow [latest documentation for rpm
 
 rpmautospec utilizes two RPM macros:
 
-1. `autorel` — to populate `Release`
+1. `autorelease` — to populate `Release`
 2. `autochangelog` — to figure out changelog
 
 If you want your upstream spec file to also work well when `rpmautospec-rpm-macros` is not installed, set `Release` to this:
 
-    Release:  %{?autorel}%{!?autorel:1}
+    Release:  %{?autorelease}%{!?autorelease:1{?dist}}
 
-This construct uses `autorel` macro if it's defined, and if it's not, it sets release to 1.
+This construct uses `autorelease` macro if it's defined, and if it's not, it sets release to `1{?dist}`.
 
 For `%changelog`, you don't need to include the changelog file upstream and you can have it downstream only, which makes sense - changelog is specific to a release.
 


### PR DESCRIPTION
The `%autorel` macro was renamed to `%autorelease` in rpmautospec 0.2:
https://docs.pagure.org/fedora-infra.rpmautospec/autorelease.html

Also make sure to include `%{?dist}` if `%autorelease` is not defined.

Signed-off-by: Daiki Ueno <dueno@redhat.com>