### PR TITLE
Remove rpmautospec link from the heading

### DIFF
--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -143,7 +143,7 @@ it means you forgot to initialize the metadata tree with `fmf init`
 and include the `.fmf` directory in the pull request.
 See [Testing Farm documentation](/docs/testing-farm) for more information.
 
-## Does packit work with [rpmautospec](https://docs.pagure.org/Fedora-Infra.rpmautospec/)?
+## Does packit work with rpmautospec?
 
 Good that you ask. It does, packit works with rpmautospec quite nicely.
 


### PR DESCRIPTION
Hugo does not seem to like links in the headings since it creates a
nested link resulting in weird indentation/line breaks. Keep the link to
rpmautospec only in the paragraph.

See the attached screenshots for before and after (in the before screenshot, the nav in the right column is also somewhat broken)

Before:

![screenshot_20220517_150405](https://user-images.githubusercontent.com/28452337/168817517-6b1da5e8-f9c1-469a-ae56-342fb1f9b2d7.png)

After:

![screenshot_20220517_150539](https://user-images.githubusercontent.com/28452337/168817661-10de87dd-9c3e-4bf7-bd84-f938d63f4a9e.png)
