### PR TITLE
autorelease usage suggestion fallback case seems wrong

### DIFF
--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -140,9 +140,9 @@ rpmautospec utilizes two RPM macros:
 
 If you want your upstream spec file to also work well when `rpmautospec-rpm-macros` is not installed, set `Release` to this:
 
-    Release:  %{?autorelease}%{!?autorelease:1{?dist}}
+    Release:  %{?autorelease}%{!?autorelease:1%{?dist}}
 
-This construct uses `autorelease` macro if it's defined, and if it's not, it sets release to `1{?dist}`.
+This construct uses `autorelease` macro if it's defined, and if it's not, it sets release to `1%{?dist}`.
 
 For `%changelog`, you don't need to include the changelog file upstream and you can have it downstream only, which makes sense - changelog is specific to a release.
 


### PR DESCRIPTION
https://packit.dev/docs/faq/#does-packit-work-with-rpmautospec says the following:

> `Release:  %{?autorelease}%{!?autorelease:1{?dist}}`
>
> This construct uses `autorelease` macro if it’s defined, and if it’s not, it sets release to `1{?dist}`.

I'm afraid this statement is technically correct, and, if `autorelease` macro happens to be undefined, the expression evaluates to a literal `1{?dist}` =)

It was meant to be `%{?autorelease}%{!?autorelease:1%{?dist}}` with a `%` in `%{?dist}`, right?
