### PR TITLE
document Packit auth with Kerberos using fas_user

### DIFF
--- a/content/docs/configuration.md
+++ b/content/docs/configuration.md
@@ -777,7 +777,7 @@ The acceptable names are the same as for the package config:
  Key name                     | Type            | Description
 ------------------------------|-----------------|----------------------------------------------------------------------
  `debug`                      | bool            | enable debug logs
- `fas_user`                   | string          | username in Fedora account system (to perform kinit if needed)
+ `fas_user`                   | string          | username in Fedora account system; this is utilized when authenticating with Bodhi using Kerberos
  `authentication`             | dict            | tokens for services (GitHub, Pagure)
  `upstream_git_remote`        | string          | name of the git remote to discover upstream project URL from
 


### PR DESCRIPTION
when `fas_user` is set, Packit authenticates using Kerberos instead of
OIDC - no prompts, everything is automated

Yes, Packit does kinit when you set fas_user AND kerberos_keytab, which
is our server use case, not for our users.

Related packit/packit#1635