### PR TITLE
Fix naming inconsistency of create-update command

### DIFF
--- a/content/docs/CLI/_index.md
+++ b/content/docs/CLI/_index.md
@@ -15,7 +15,7 @@ follow [our guide](/docs/guide/#have-packit-tooling-installed-locally).
 
 * [build](/docs/cli/build/)
 * [copr-build](/docs/cli/copr-build/)
-* [create-bodhi-update](/docs/cli/create-bodhi-update/)
+* [create-update](/docs/cli/create-bodhi-update/)
 * [init](/docs/cli/init/)
 * [local-build](/docs/cli/local-build/)
 * [propose-downstream](/docs/cli/propose-downstream/)

--- a/content/docs/CLI/create-bodhi-update.md
+++ b/content/docs/CLI/create-bodhi-update.md
@@ -4,7 +4,7 @@ date: 2019-06-28
 weight: 5
 ---
 
-# `packit create-bodhi-update`
+# `packit create-update`
 
 Create a new bodhi update for the latest Fedora build of the upstream project.
 


### PR DESCRIPTION
Fix the naming inconsistency to follow actual cli command name (`packit create-update`)