### PR TITLE
SRPMs are built in Copr by default for installations since September 6

### DIFF
--- a/content/docs/configuration.md
+++ b/content/docs/configuration.md
@@ -373,6 +373,7 @@ instead of the location defined in the spec-file.
 For now, this key is used in Packit Service as an indicator to build your SRPMs in Copr and 
 the dependencies are then installed into the Copr build environment each time the build is triggered.
 Be aware that this is a preparation phase, and we want to build all the packages in Copr by default.
+As a next step, we use Copr build environment also for Packit GitHub app installations since September 6, 2022.
 
 #### packit_instances
 (*list of strings*) If you want to help us with catching issues or need some feature sooner than other users,

--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -147,12 +147,8 @@ For `%changelog`, you don't need to include the changelog file upstream and you 
 
 ## How do I install dependencies for my commands in packit-service?
 
-We are running all commands, defined by you, in a sandbox which is locked-down.
-At the moment we don't have any mechanism for you to define the dependencies
-you need and us making them available for you.
-
-In the meantime we are solving these requests one by one, so [please reach out
-to us](#how-can-i-contact-you).
+For installations made before September 6, 20222,
+Packit runs all the commands, defined by you, in a sandbox which is locked-down.
 
 As for the actions needed during SRPM builds, we are transitioning into a solution where SRPMs are built directly in Copr
 and  therefore for these actions, you can define your dependencies via [`srpm_build_deps`

--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -147,7 +147,7 @@ For `%changelog`, you don't need to include the changelog file upstream and you 
 
 ## How do I install dependencies for my commands in packit-service?
 
-For installations made before September 6, 20222,
+For installations made before September 6, 2022,
 Packit runs all the commands, defined by you, in a sandbox which is locked-down.
 
 As for the actions needed during SRPM builds, we are transitioning into a solution where SRPMs are built directly in Copr

--- a/content/docs/guide.md
+++ b/content/docs/guide.md
@@ -321,15 +321,16 @@ If yes, let's proceed to the next level.
 #### The project has successful builds inside the service
 
 If a SRPM can be created locally, all should be good in the service as well.
-That's the theory. In practice, your laptop and packit service sandbox
-environment are vastly different. One thing which can happen easily is that a
-command is not available in the sandbox. Also, all the commands are run using
-an unprivileged user - you can't install anything or perform any privileged
-operation. If you want to tweak the environment,
+That's the theory. In practice, your laptop and packit service
+environment are vastly different. For installations made before September 6, 20222,
+Packit's own sandboxing system is used -- there, you're commands are run as unprivileged user
+and you can't install anything or perform any privileged operation.
+If you want to tweak the environment,
 you can do the SRPM builds in Copr environment instead.
 There, you can specify the requirements yourself.
-The change can be done by specifying
-a [`srpm_build_deps` option](https://packit.dev/docs/configuration/#srpm_build_deps).
+This is the default for installations made since September 6, 2022,
+but the change can also be done by specifying
+an [`srpm_build_deps` option](https://packit.dev/docs/configuration/#srpm_build_deps).
 (We are planning to move there all the builds in the future.)
 In any case, feel free to reach out to us if you are having troubles,
 and we'd be glad to help.

--- a/content/docs/guide.md
+++ b/content/docs/guide.md
@@ -322,8 +322,8 @@ If yes, let's proceed to the next level.
 
 If a SRPM can be created locally, all should be good in the service as well.
 That's the theory. In practice, your laptop and packit service
-environment are vastly different. For installations made before September 6, 20222,
-Packit's own sandboxing system is used -- there, you're commands are run as unprivileged user
+environment are vastly different. For installations made before September 6, 2022,
+Packit's own sandboxing system is used -- there, your commands are run as unprivileged user
 and you can't install anything or perform any privileged operation.
 If you want to tweak the environment,
 you can do the SRPM builds in Copr environment instead.

--- a/content/docs/reproduce-locally.md
+++ b/content/docs/reproduce-locally.md
@@ -23,7 +23,8 @@ Packit will create a SRPM out of the current checkout. Simple and clear.
 ## SRPM builds in Copr
 
 When your SRPM is being built in Copr (because [`srpm_build_deps`]({{< ref
-"configuration.md#srpm_build_deps" >}}) is set in your packit config), this
+"configuration.md#srpm_build_deps" >}}) is set in your packit config or
+you installed Packit GitHub application since September 6, 2022), this
 section describes how you can reproduce the build procedure locally.
 
 We invoke our CLI command `packit prepare-sources` in the Copr environment,

--- a/content/posts/copr-srpms.md
+++ b/content/posts/copr-srpms.md
@@ -97,7 +97,9 @@ to kick off this process and therefore started opening PRs with dependencies con
 the RPM builds functionality the most. During this phase, you can reach out to us with your feedback and we can
 improve it even more!
 
-The next step will be to get rid of using our sandbox for building SRPMs at all. We do not have an exact date
+As a next step, we use the new approach for GitHub app installations made since September 6, 20222.
+
+The last step will be to get rid of using our sandbox for building SRPMs at all. We do not have an exact date
 for this currently and will act accordingly to your feedback, but we are looking forward to that moment.
 Since we don't want to break your CI results because of missing dependencies, we will use the previously linked list of deps.
 As the list is pretty long, we encourage you to define your dependencies on your own. If you will

--- a/content/posts/copr-srpms.md
+++ b/content/posts/copr-srpms.md
@@ -97,7 +97,7 @@ to kick off this process and therefore started opening PRs with dependencies con
 the RPM builds functionality the most. During this phase, you can reach out to us with your feedback and we can
 improve it even more!
 
-As a next step, we use the new approach for GitHub app installations made since September 6, 20222.
+As a next step, we use the new approach for GitHub app installations made since September 6, 2022.
 
 The last step will be to get rid of using our sandbox for building SRPMs at all. We do not have an exact date
 for this currently and will act accordingly to your feedback, but we are looking forward to that moment.


### PR DESCRIPTION
Docs for packit/packit-service#1636

Signed-off-by: Frantisek Lachman <flachman@redhat.com>