### PR TITLE
fix(bodhi): remove ‹commit› rights requirement

### DIFF
--- a/content/docs/Configuration/_index.md
+++ b/content/docs/Configuration/_index.md
@@ -882,8 +882,6 @@ For now, the Bodhi update is created only for builds submitted by the Packit FAS
 This is just for the early stage of this job, and
 we can easily turn off that filter.
 Let us know if you need this condition to be removed.
-Also, you need to give `commit` rights to `packit` FAS user
-for your package in dist-git settings.
 
 There is no UI provided by Packit for the job,
 but it is visible across Fedora systems

--- a/content/docs/fedora-releases-guide.md
+++ b/content/docs/fedora-releases-guide.md
@@ -153,7 +153,5 @@ jobs:
 ```
 
 The packit config is loaded from the commit the build is triggered from.
-Just don't forget to give `commit` rights to `packit` FAS user
-for your package in dist-git settings so Packit can create the update for you.
 The `issue_repository` configuration key mentioned in the Koji build job applies here as well.
 

--- a/content/posts/downstream-automation.md
+++ b/content/posts/downstream-automation.md
@@ -108,8 +108,6 @@ jobs:
 ```
 
 The packit config is loaded from the commit the build is triggered from.
-Just don't forget to give `commit` rights to `packit` FAS user
-for your package in dist-git settings so Packit can create the update for you.
 
 Here is an example of the resulting Bodhi update:
 


### PR DESCRIPTION
Remove all mentions of the ‹commit› rights in the dist-git requirement, since it has been allowed from the Bodhi side to create updates for anyone.

Related to packit/packit-service#1721

Signed-off-by: Matej Focko <mfocko@redhat.com>