### PR TITLE
Add example for cloud costs reporting in Testing Farm

### DIFF
--- a/content/docs/Configuration/examples.md
+++ b/content/docs/Configuration/examples.md
@@ -229,6 +229,27 @@ jobs:
   ```
 {{< /details >}}
 
+{{< details title="Tag cloud resources in Testing Farm" >}}
+Tag cloud resources in Testing Farm to a specific team or project.
+Make sure to update `sst_change_me` to your RHEL SST name or name
+of the project. If not set, cloud costs are reported against
+`Packit Service`. The `BusinessUnit` key name is required, please
+do not change it.
+```yaml
+- job: tests
+  trigger: pull_request
+  targets:
+    - fedora-all
+  # Tag cloud resources for tmt
+  tf_extra_params:
+    environments:
+      - settings:
+          provisioning:
+            tags:
+              BusinessUnit: sst_change_me
+```
+{{< /details >}}
+
 ### Fedora release automation
 
 {{< details title="Creating dist-git pull requests on upstream releases" >}}

--- a/content/docs/Configuration/examples.md
+++ b/content/docs/Configuration/examples.md
@@ -230,7 +230,7 @@ jobs:
 {{< /details >}}
 
 {{< details title="Tag cloud resources in Testing Farm" >}}
-Tag cloud resources in Testing Farm to a specific team or project.
+Tag cloud resources in Testing Farm to a specific Red Hat team or a project. If you are not a Red Hat employee, this section is not relevant for you.
 Make sure to update `sst_change_me` to your RHEL SST name or name
 of the project. If not set, cloud costs are reported against
 `Packit Service`. The `BusinessUnit` key name is required, please


### PR DESCRIPTION
Document the way teams can adjust the cloud costs reporting in Testing Farm.

This will be used to split the `Packit Service` cloud cost between users of Packit, for better granularity.