### PR TITLE
Fix commands for fetching changes from packit dist-git PRs

### DIFF
--- a/content/docs/Configuration/_index.md
+++ b/content/docs/Configuration/_index.md
@@ -780,7 +780,7 @@ of the Packit's pull request and push it (with a fix) to your fork (as it is not
 created in the Packit's fork):
 
 
-    git fetch ssh://$USER.fedoraproject.org/forks/packit/rpms/$YOUR_PACKAGE.git refs/heads/*:refs/remotes/packit/*
+    git fetch https://src.fedoraproject.org/forks/packit/rpms/$YOUR_PACKAGE.git refs/heads/*:refs/remotes/packit/*
     git cherry-pick packit/$VERSION-$BRANCH-update-propose_downstream
 
 ##### pull_from_upstream
@@ -838,7 +838,7 @@ If you need to do any change in the pull request, you need to locally fetch the 
 of the Packit's pull request and push it (with a fix) to your fork (as it is not possible to push to the branch 
 created in the Packit's fork):
 
-    git fetch ssh://$USER.fedoraproject.org/forks/packit/rpms/$YOUR_PACKAGE.git refs/heads/*:refs/remotes/packit/*
+    git fetch https://src.fedoraproject.org/forks/packit/rpms/$YOUR_PACKAGE.git refs/heads/*:refs/remotes/packit/*
     git cherry-pick packit/$VERSION-$BRANCH-update-pull_from_upstream
 
 For more details, check [our release guide](/docs/fedora-releases-guide).


### PR DESCRIPTION
`ssh://$USER.fedoraproject.org` is plain wrong and probably should have been `ssh://$USER@pkgs.fedoraproject.org`, however using HTTPS allows non-authenticated read-only access, which is sufficient for fetching and eliminates the need for the `$USER` variable.