### PR TITLE
Clarify filter rules

### DIFF
--- a/content/docs/Configuration/_index.md
+++ b/content/docs/Configuration/_index.md
@@ -144,7 +144,8 @@ The fields for a dictionary item in the list are the following:
 - *dest*: Path in the dist-git repo, where paths in `src` should be synced to.
 - *mkpath*: Flag to indicate if missing path components in `dest` should be created or not (default: false).
 - *delete*: Flag to indicate if extra content from `dest` should be deleted (default: false).
-- *filters*: List of [rsync filter rules] to be used during syncing.
+- *filters*: List of [rsync filter rules] to be used during syncing. Note that the rules apply relative
+  to the source and/or destination path (e.g. a `protect` filter applies relative to `dest` path)
 
 [rsync filter rules]: https://www.man7.org/linux/man-pages/man1/rsync.1.html#FILTER_RULES
 


### PR DESCRIPTION
It is helpful for the documentation on `files_to_sync` to be idiot-proof (i.e. me) because these are only run at `propose_downstream` where it is too late to fix.