### PR TITLE
Use 'light' style for the footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -220,7 +220,7 @@ const config = {
         ],
       },
       footer: {
-        style: "dark",
+        style: "light",
         links: [
           {
             title: "Docs",


### PR DESCRIPTION
In the light mode, the contact links are not well readable with the 'dark' one.