### PR TITLE
fix: use tagline as front-page description

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -203,7 +203,7 @@ export default function Home(): JSX.Element {
   return (
     <Layout
       title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />"
+      description="Automate and ease the work of maintainers and developers"
     >
       <HomepageHeader />
       <PackitDescription />


### PR DESCRIPTION
When linking the web, description is used for the preview, e.g. on Matrix or Discord.

#i_am_a_dummkopf