### PR TITLE
Fix escaping in regexes in examples

### DIFF
--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -482,8 +482,8 @@ jobs:
   trigger: release
   dist_git_branches: 
     - fedora-all
-  upstream_tag_include: "^2\..+"
-  upstream_tag_exclude: "^.+\.1\..+"
+  upstream_tag_include: "^2\\..+"
+  upstream_tag_exclude: "^.+\\.1\\..+"
 ```
 
 </details>


### PR DESCRIPTION
Single backslash makes yaml parser complain:
`found unknown escape character '.' while scanning a double-quoted scalar`.