### PR TITLE
Remove ignore-missing-autosetup from documentation

### DIFF
--- a/docs/cli/source-git/init.md
+++ b/docs/cli/source-git/init.md
@@ -118,7 +118,4 @@ It will be the base of your source-git repository.
                                   configured in the Packit configuration.
       --pkg-name TEXT             The name of the package in the distro. Defaults
                                   to the directory name of DIST_GIT.
-      --ignore-missing-autosetup  Do not require %autosetup macro to be used in
-                                  %prep section of specfile. By default,
-                                  %autosetup is required.
       -h, --help                  Show this message and exit.


### PR DESCRIPTION
**Documentation Update: Remove 'ignore-missing-autosetup' Section**

This pull request removes the 'ignore-missing-autosetup' section from the documentation as it's no longer relevant to the current configuration. The removal ensures that our documentation remains accurate and up-to-date.

**Changes Made:**
- Removed the 'ignore-missing-autosetup' section from the documentation.

**Why this is done:**
The 'ignore-missing-autosetup' option has been deprecated and is no longer part of our configuration. Removing it from the documentation helps users find accurate and applicable information.

**Impact:**
- This change simplifies the documentation and prevents confusion for users who might still refer to the deprecated option.

**Additional Notes:**
- Verified all other sections for consistency with the updated content.
- No other functional changes have been made to the documentation.

This pull request should be merged when the [issue 2020](https://github.com/packit/packit/issues/2020) is closed y el pull request [emove: --ignore-missing-autosetup from source-git init](https://github.com/packit/packit/pull/2053) is closed and merged.