### PR TITLE
fix(actions): use correct name of the variables

### DIFF
--- a/docs/configuration/actions.md
+++ b/docs/configuration/actions.md
@@ -181,8 +181,8 @@ actions:
 
 Additionally, packit sets several environment variables for the actions:
 
-* `PACKIT_UPSTREAM_PROJECT_NAME` — set to the `upstream_package_name` value, if any
-* `PACKIT_DOWNSTREAM_PROJECT_NAME` — set to the `downstream_package_name` value, if any
+* `PACKIT_UPSTREAM_PACKAGE_NAME` — set to the `upstream_package_name` value, if any
+* `PACKIT_DOWNSTREAM_PACKAGE_NAME` — set to the `downstream_package_name` value, if any
 * `PACKIT_CONFIG_PACKAGE_NAME` — set to the package name key for the `packages` dictionary in a monorepo project,
 falls back to the `downstream_package_name` or, if not set, to `upstream_package_name`
 


### PR DESCRIPTION
Noticed it when setting up `pull-from-upstream` on my package. Please don't ask how did I notice it…

You can see them being passed here: https://github.com/packit/packit/blob/80d9002ef29c69c5190b21b33b8624a77dc5c897/packit/config/common_package_config.py#L475-L483