### PR TITLE
Clarify koji_build documentation

### DIFF
--- a/docs/configuration/downstream/koji_build.md
+++ b/docs/configuration/downstream/koji_build.md
@@ -49,8 +49,8 @@ For Koji builds from upstream, see [`upstream_koji_build`](/docs/configuration/u
   instead of the real production builds
 * **allowed_pr_authors** - a list of FAS accounts of PR authors whose merged pull requests will trigger koji builds
   (defaults to `['packit']`).
-* **allowed_committers** - a list of FAS accounts of committers whose pushes to dist-git will trigger koji builds
-  (defaults to an empty list).
+* **allowed_committers** - a list of FAS accounts of committers whose direct pushes to dist-git will trigger koji builds
+  (defaults to an empty list). You do not need to specify this parameter if you want to have builds from PRs.
 
 ### Example
 
@@ -58,6 +58,7 @@ For Koji builds from upstream, see [`upstream_koji_build`](/docs/configuration/u
 jobs:
 - job: koji_build
   trigger: commit
+  allowed_committers: ["jsmith"]
   dist_git_branches:
     - fedora-all
     - epel-8

--- a/docs/configuration/downstream/koji_build.md
+++ b/docs/configuration/downstream/koji_build.md
@@ -50,7 +50,7 @@ For Koji builds from upstream, see [`upstream_koji_build`](/docs/configuration/u
 * **allowed_pr_authors** - a list of FAS accounts of PR authors whose merged pull requests will trigger koji builds
   (defaults to `['packit']`).
 * **allowed_committers** - a list of FAS accounts of committers whose direct pushes to dist-git will trigger koji builds
-  (defaults to an empty list). You do not need to specify this parameter if you want to have builds from PRs.
+  (defaults to an empty list). You do not need to configure this option if you want to have koji builds triggered only by merged pull requests.
 
 ### Example
 


### PR DESCRIPTION
* emphasis that allowed_committers is not needed if you will use PR only
* add allowed_committers to example, because if you need only koji_build (without other pull-from-upstream jobs) it may confuse users why the build did not started. It confused me definitelly.