### PR TITLE
docs: drop misleading `...` - pull from upstream examples

### DIFF
--- a/docs/configuration/downstream/pull_from_upstream.md
+++ b/docs/configuration/downstream/pull_from_upstream.md
@@ -83,7 +83,7 @@ You can also append `&component={your-package-name}` to the query above to const
 
 ```yaml
 upstream_project_url: https://github.com/packit/packit
-...
+
 jobs:
 - job: pull_from_upstream
   trigger: release

--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -537,7 +537,7 @@ do not change it.
 
 ```yaml
 upstream_project_url: https://github.com/packit/packit
-...
+
 jobs:
 - job: pull_from_upstream
   trigger: release
@@ -552,7 +552,7 @@ jobs:
 
 ```yaml
 upstream_project_url: https://github.com/packit/packit
-...
+
 jobs:
 - job: pull_from_upstream
   trigger: release


### PR DESCRIPTION
The `...` is yaml syntax for indication of the end of the document.

https://yaml.org/spec/1.1/#document%20boundary%20marker/

The examples will result in a yaml parse error.

```
$ packit pull-from-upstream
2023-10-30 09:39:53.797 package_config.py ERROR  Cannot load package config /home/jamacku/Packages/fedora/forks/nghttp2/.packit.yml.
2023-10-30 09:39:53.797 package_config.py ERROR    parser says
  in "<unicode string>", line 5, column 1:
    jobs:
    ^
  expected '<document start>', but found '<block mapping start>'
2023-10-30 09:39:53.797 utils.py          ERROR  Please correct data and retry.
```