### PR TITLE
Remove mentions of Packit Libera channel

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -272,13 +272,6 @@ const config = {
               },
               {
                 html: `
-                  <a href="https://libera.chat/">
-                    #packit:libera.chat
-                  </a> (IRC)
-                `,
-              },
-              {
-                html: `
                   <a href="mailto:hello@packit.dev">hello@packit.dev</a>
                 `,
               },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -181,9 +181,6 @@ function Contacts() {
             (Element / Matrix)
           </li>
           <li>
-            <Link to="https://libera.chat/">#packit:libera.chat</Link> (IRC)
-          </li>
-          <li>
             <Link to="mailto:hello@packit.dev">hello@packit.dev</Link>
           </li>
           <li>


### PR DESCRIPTION
The bridge to Matrix is now down and we agreed on not promoting this channel further.