### PR TITLE
Change docs for loading config for downstream jobs

### DIFF
--- a/docs/configuration/downstream/bodhi_update.md
+++ b/docs/configuration/downstream/bodhi_update.md
@@ -10,9 +10,7 @@ Create a new update in
 Koji build.
 A Packit config file needs to be in the dist-git repository
 to allow this job to be triggered.
-Packit loads the config from the commit the build is triggered from
-(therefore, the Packit configuration needs to be in each branch
-Packit should act upon).
+Packit loads the config from the default dist-git branch (usually `rawhide`). Packit configs on other branches are ignored.
 
 For now, the Bodhi update is created only for builds submitted by the Packit FAS user.
 (See [`koji_build`](/docs/configuration/downstream/koji_build) job for more details on how to set this up.)

--- a/docs/configuration/downstream/koji_build.md
+++ b/docs/configuration/downstream/koji_build.md
@@ -10,9 +10,7 @@ Trigger the build in
 as a reaction to a new dist-git commit.
 A Packit config file needs to be in the dist-git repository
 to allow this job to be triggered.
-Packit loads the config from the newly pushed commit
-(therefore, the Packit configuration needs to be in each branch
-Packit should act upon).
+Packit loads the config from the default dist-git branch (usually `rawhide`). Packit configs on other branches are ignored.
 
 The build is triggered only for commits with a spec-file change.
 

--- a/docs/fedora-releases-guide.md
+++ b/docs/fedora-releases-guide.md
@@ -320,8 +320,7 @@ After having the dist-git content updated, you can easily automate also building
 You can simply configure Packit to react to the new commits in your dist-git repository and create
 Koji builds by having
 a Packit configuration (when using `propose_downstream` job, you can configure Packit to sync the file) in your 
-dist-git repository that includes a `koji_build` job (the Packit configuration needs to be in each branch
-Packit should act upon).
+default branch (usually `rawhide`) of the dist-git repository that includes a `koji_build` job.
 Then, if Packit is informed (via fedora-messaging bus) about a new commit in the configured dist-git branch, it submits a new build in Koji
 like maintainers usually do. (The commits without any spec file change are skipped.)
 
@@ -360,9 +359,8 @@ issue to retrigger the builds (see [`issue_repository`](/docs/configuration#issu
 
 ## Bodhi update job
 Lastly, you can again similarly to Koji builds, configure Packit to react to successful Koji builds and create
-Bodhi updates by having a Packit configuration in your dist-git repository that includes a `bodhi_update` job
-(the Packit configuration needs to be in each branch
-Packit should act upon).
+Bodhi updates by having a Packit configuration in your 
+default branch (usually `rawhide`) of the dist-git repository that includes a `bodhi_update` job.
 Once Packit is informed (via fedora-messaging bus) about the successful Koji build for the configured branch,
 it creates a new update for that branch in Bodhi for you.
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -204,11 +204,12 @@ As a format, it uses YAML and here are all the valid names:
 
 And where do you need to place this config file?
 Whenever you need to use Packit -- the concept is easy:
-Packit loads the config file from the repository and commit related to the event it reacts to.
+For upstream jobs, Packit loads the config file from the repository and commit related to the event it reacts to.
 E.g. if Packit reacts to a pull request, it takes config from the HEAD commit of the pull request,
-if Packit works with releases, the release commit is used
-and if Packit works with downstream Koji build,
-the respective dist-git commit is used.
+if Packit works with releases, the release commit is used.
+
+For downstream jobs, Packit always loads the config from the default branch of the dist-git repository
+(usually `rawhide`).
 
 You know how to call this file, where to put it, but what should you fill inside?
 


### PR DESCRIPTION
We have changed the behaviour of loading config for downstream jobs: for all of them, the config in default dist-git branch is used. Related to packit/packit-service#2272