### PR TITLE
Include agile repository documentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
       - deployment-docs-updated
       - research-docs-updated
       - specfile-docs-updated
+      - agile-docs-updated
 
 jobs:
   deploy:

--- a/Makefile
+++ b/Makefile
@@ -25,5 +25,10 @@ import:
 	pip3 install pydoc-markdown
 	$(MAKE) -C .specfile-docs generate-api-docs
 	mv .specfile-docs/docs specfile
+	
+	# agile
+	([[ -d .agile-docs ]] && rm -rf .agile-docs agile) || true
+	git clone https://github.com/packit/agile.git .agile-docs
+	mv .agile-docs/docs agile
 
 .PHONY: run-dev import

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -68,6 +68,11 @@ const developmentSections = [
     "https://github.com/packit/research/tree/main",
   ),
   new Section(
+    "agile",
+    "Agile",
+    "https://github.com/packit/agile/tree/main/docs",
+  ),
+  new Section(
     "specfile",
     "specfile library",
     "https://github.com/packit/specfile/tree/main/docs",


### PR DESCRIPTION
We've agreed on upstreaming all the information we have about the team processes and have it in one place, together with the roles, and have it as a subpage of packit.dev.