### PR TITLE
fix(dg/koji): add flowchart for precheck

### DIFF
--- a/docs/configuration/downstream/koji_build.md
+++ b/docs/configuration/downstream/koji_build.md
@@ -76,6 +76,56 @@ Packit dist-git configuration.
    - `all_admins` alias - allowing all users with admin access to the dist-git repo
    - `all_committers` alias - allowing all users with commit access to the dist-git repo
 
+:::info Processing of dist-git events from Pagure
+
+```mermaid
+flowchart TD;
+  S[Event is registered]
+  F{Specfile changed}
+  A{Type of event}
+  B{"Is build configured
+  for the branch?"}
+  C{"Has commit been
+  pushed by Pagure?"}
+  D{"Has the commit
+  been pushed
+  by someone in
+  <code>allowed_committers</code>?"}
+  E{"Is it a PR merge?"}
+  G{"Is the PR author in
+  <code>allowed_pr_authors</code>?"}
+  H{"Is the actor
+  a packager?"}
+
+  OK(((Run build)))
+  NOK((Skip build))
+
+  S --> F
+  F -. No   .-> NOK
+  F -. Yes  .-> A
+
+  A -- Comment --> H
+  H -. No      .-> NOK
+  H -- Yes     --> OK
+
+  A -- Push --> B
+  B -. No   .-> NOK
+  B -- Yes  --> C
+  C -- Yes  --> E
+  C -. No   .-> D
+  D -. No   .-> NOK
+  D -- Yes  --> OK
+  E -. No   .-> NOK
+  E -- Yes  --> G
+  G -. No   .-> NOK
+  G -- Yes  --> OK
+```
+
+Because of the potential issues with rendering:
+- dotted lines represent _no_
+- continous lines represent _yes_
+:::
+
 ### Example
 
 ```yaml

--- a/yarn.lock
+++ b/yarn.lock
@@ -7074,19 +7074,19 @@ semver-diff@^3.1.1:
     semver "^6.3.0"
 
 semver@^5.4.1:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
-  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
 semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 semver@^7.3.2, semver@^7.3.4, semver@^7.3.7, semver@^7.3.8:
-  version "7.5.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
-  integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4392,9 +4392,9 @@ flux@^4.0.1:
     fbjs "^3.0.1"
 
 follow-redirects@^1.0.0, follow-redirects@^1.14.7:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
-  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
+  integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
 
 fork-ts-checker-webpack-plugin@^6.5.0:
   version "6.5.3"


### PR DESCRIPTION
Add flowchart that should be explicit about the way Packit decides whether to run or skip Koji build when a dist-git event is registered.

Fixes #826