### PR TITLE
fix(docs/koji): add note about ‹scratch›

### DIFF
--- a/docs/configuration/upstream/upstream_koji_build.md
+++ b/docs/configuration/upstream/upstream_koji_build.md
@@ -25,6 +25,14 @@ the more explicit `upstream_koji_build`.)
 
 ## Optional parameters
 
+* **scratch** - (boolean) used to create a scratch (test) build instead of the real production build
+
+  :::warning
+
+  Needs to be set to `true` for upstream Koji builds.
+
+  :::
+
 * **targets** - (a list of) targets we want to build for,
   list of supported targets can be listed using with `koji list-targets`.
   You can also use the [aliases provided by Packit](/docs/configuration#aliases)


### PR DESCRIPTION
Reported by @pvalena during set up of upstream Koji builds for `dracut`.