### PR TITLE
Testing Farm API documentation changed location

### DIFF
--- a/docs/configuration/upstream/tests.md
+++ b/docs/configuration/upstream/tests.md
@@ -138,12 +138,12 @@ distro (otherwise the default would be `centos-stream-8`) and for
 * **tmt_plan** - Run plans by the given name. Can be passed as a regular
   expression.
 * **tf_post_install_script** - Bash script as a string to run during the guest provisioning. 
-* **tf_extra_params** - a free-form dictionary that allows specifying extra parameters to the Testing Farm. 
-For a complete list of parameters, refer to the [Testing Farm documentation](https://testing-farm.gitlab.io/api/#operation/requestsPost). 
-The dictionary must follow the structure of the Testing Farm request. Options specified in the dictionary have the 
-highest precedence, i.e. can override Packit's defaults. They are being merged with the Packit's values, the only exception
-is the `artifacts` list, which is combined with the artifact passed by Packit. Also, beware of indentation-sensitivity of the YAML format. 
-You can verify that the option is processed correctly using a [YAML parser](https://yaml-online-parser.appspot.com/). Refer to the [configuration examples](/docs/configuration/examples/#tests) for more information.
+* **tf_extra_params** - A free-form dictionary that allows specifying extra parameters to the Testing Farm.
+  For a complete list of parameters, refer to the [Testing Farm documentation](ttps://api.testing-farm.io/redoc#operation/request_a_new_test_v0_1_requests_post).
+  The dictionary must follow the structure of the Testing Farm request. Options specified in the dictionary have the
+  highest precedence, i.e. can override Packit's defaults. They are being merged with the Packit's values, the only exception
+  is the `artifacts` list, which is combined with the artifact passed by Packit. Also, beware of indentation-sensitivity of the YAML format.
+  You can verify that the option is processed correctly using a [YAML parser](https://yaml-online-parser.appspot.com/). Refer to the [configuration examples](/docs/configuration/examples/#tests) for more information.
 * **skip_build** - Whether to skip the build phase and only run tests (defaults to false). 
   Enabling this will cause no Copr build to be built and installed into the testing environment, 
   only submitting request to Testing Farm (the selected components to be installed should be part of the TMT definitions).
@@ -488,6 +488,6 @@ If you have found an issue or have an RFE, you can file an [issue in nucleus pro
 [fedora-tmt]: https://docs.fedoraproject.org/en-US/ci/tmt
 [spec]: https://tmt.readthedocs.io/en/latest/spec.html
 [systemd-tests]: https://github.com/systemd-rhel/tests
-[testing-farm-api]: https://testing-farm.gitlab.io/api
+[testing-farm-api]: https://api.testing-farm.io
 [issues]: https://gitlab.com/testing-farm/general/-/issues
-[tf]: https://docs.testing-farm.io/Testing%20Farm/0.1/index.html
+[tf]: https://docs.testing-farm.io

--- a/weekly/2021.md
+++ b/weekly/2021.md
@@ -48,7 +48,7 @@ Let's see what happened in Packit in 2021.
 
 ## Week 5 (February 1st - February 5th)
 
-- The service uses new Testing Farm ([API](https://testing-farm.gitlab.io/api/)).
+- The service uses new Testing Farm ([API](https://api.testing-farm.io)).
   We are still working on better user experience and fixing bugs.
   ([packit-service#875](https://github.com/packit/packit-service/pull/875))
 - MatejF refactored permission system on pull requests and issues comments and


### PR DESCRIPTION
Update docs to point to the new location.