### PR TITLE
Use matrix.to in the link to Matrix room

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -275,7 +275,7 @@ const config = {
             items: [
               {
                 html: `
-                  <a href="https://matrix.to/#/%23packit:fedora.im">
+                  <a href="https://matrix.to/#/#packit:fedora.im?web-instance[element.io]=chat.fedoraproject.org">
                     #packit:fedora.im
                   </a> (Matrix)
                 `,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -275,9 +275,9 @@ const config = {
             items: [
               {
                 html: `
-                  <a href="https://chat.fedoraproject.org/#/room/#packit:fedora.im">
+                  <a href="https://matrix.to/#/%23packit:fedora.im">
                     #packit:fedora.im
-                  </a> (Element / Matrix)
+                  </a> (Matrix)
                 `,
               },
               {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -175,10 +175,10 @@ function Contacts() {
         <h2 id="contact">Contact</h2>
         <ul>
           <li>
-            <Link to="https://chat.fedoraproject.org/#/room/#packit:fedora.im">
+            <Link to="https://matrix.to/#/%23packit:fedora.im">
               #packit:fedora.im
             </Link>{" "}
-            (Element / Matrix)
+            (Matrix)
           </li>
           <li>
             <Link to="mailto:hello@packit.dev">hello@packit.dev</Link>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -175,7 +175,7 @@ function Contacts() {
         <h2 id="contact">Contact</h2>
         <ul>
           <li>
-            <Link to="https://matrix.to/#/%23packit:fedora.im">
+            <Link to="https://matrix.to/#/#packit:fedora.im?web-instance[element.io]=chat.fedoraproject.org">
               #packit:fedora.im
             </Link>{" "}
             (Matrix)


### PR DESCRIPTION
<!-- TODO list -->

<!-- notes for reviewers -->
I don't really know how docusaurus (or the website in general) works and just replaced the links in both files I've found them. Hope it's ok.

Also changing "Element / Matrix" to just "Matrix", as matrix client is not relevant to the room.

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes
#863

<!-- release notes footer -->

RELEASE NOTES BEGIN

Matrix room link now uses matrix.to service

RELEASE NOTES END
