### PR TITLE
CentOS Stream release syncing: add note about lookaside

### DIFF
--- a/docs/configuration/upstream/propose_downstream.md
+++ b/docs/configuration/upstream/propose_downstream.md
@@ -93,9 +93,18 @@ We value general feedback as well, so don't hesitate to [reach out](/#contact)!
 
 :::
 
+
+:::caution
+
+At the moment, the upload to lookaside cache is being bypassed in the Packit service.
+If you prefer having this step handled by the automation, you can  
+use [Packit CLI](/docs/cli/propose-downstream) instead.
+
+:::
+
 To sync the release to CentOS Stream, you currently need to specify the following parameters:
 - `pkg_tool: centpkg` (the default is `fedpkg`)
-- `dist_git_branches`:  `c8s` and/or `c9s`. 
+- `dist_git_branches`:  a list of dist-git branches, e.g. `c8s`, `c9s`
 
 Besides that, you need to:
 1. specify the [`packages`](/docs/configuration#packages) with distinct items for Fedora and CentOS Stream. 


### PR DESCRIPTION
Lookaside cache upload is being skipped, add this to the documentation of propose-downstream.


<!-- release notes footer -->

RELEASE NOTES BEGIN

N/A

RELEASE NOTES END
