### PR TITLE
Add notes about ignoring artifacts

### DIFF
--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -111,7 +111,8 @@ create-archive:
 
 If you need to generate local archive(s) during release syncing, you can utilise e.g. `pre-sync` action
 to place the commands necessary for the creation. You also have to include the archive(s) in the list of files to
-be moved to the dist-git repo so that it is then handled by Packit from there.
+be moved to the dist-git repo so that it is then handled by Packit from there. **Note:** Beware of how Packit uploads
+files to lookaside cache or adds them to dist-git (see [this note][files_to_sync_info] for more details).
 
 
 <details>
@@ -130,6 +131,7 @@ files_to_sync:
 
 </details>
 
+[files_to_sync_info]: ./index.md#files_to_sync
 
 ### Custom changelog generation
 <details>

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -235,6 +235,21 @@ and [`pull_from_upstream`](#pull_from_upstream) jobs.
 (*list of strings or dicts*) A list of relative paths to files in the upstream
 repo which are meant to be copied to dist-git during an update.
 
+:::info
+
+All files in the dist-git repo are committed using `git add -A`. Make sure all
+artifacts are ignored either directly using glob patterns in `.gitignore` or
+indirectly, e.g. when Packit runs `fedpkg new-sources`, if you do not want to
+include the files in the commit.
+
+Files to be uploaded to lookaside cache also use this interface, where all files
+mentioned in the spec file's `Source` are uploaded to the lookaside cache, *unless*
+the file is already being tracked in dist-git. **Note:** this implies that new
+`Source` files are [always added][packit#2365] as lookaside cache as part of an
+update even if they should be tracked in dist-git instead. 
+
+:::
+
 Spec file path and config file path are always included by `packit init`
 but can be manually removed from the list.
 
@@ -251,6 +266,7 @@ The fields for a dictionary item in the list are the following:
   to the source and/or destination path (e.g. a `protect` filter applies relative to `dest` path)
 
 [rsync filter rules]: https://www.man7.org/linux/man-pages/man1/rsync.1.html#FILTER_RULES
+[packit#2365]: https://github.com/packit/packit/issues/2365
 
 ##### Examples:
 


### PR DESCRIPTION
<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Related to https://src.fedoraproject.org/rpms/jowl/pull-request/17

For some reason in that PR there were many artifacts that were committed, the reason for that is still a mystery, maybe a bug where `/tmp/sandcastle/dist-git` still had artifacts from a previous run.

This PR tries to clarify more how the files are added to dist-git and encourage the usage of `.gitignore` to exclude artifacts. Technically `fedpkg new-sources` does take care of some of these artifacts, but things can break in weird ways as we saw there.
