### PR TITLE
Add docs about PACKIT_TAG_NAME

### DIFF
--- a/docs/configuration/upstream/tests.md
+++ b/docs/configuration/upstream/tests.md
@@ -175,6 +175,7 @@ There are also environment variables set by Packit:
 * `PACKIT_BUILD_LOG_URL`
 * `PACKIT_SRPM_URL`
 * `PACKIT_COMMIT_SHA`
+* `PACKIT_TAG_NAME`, tag name from release event, not set if the test job doesn't have **release** trigger
 * `PACKIT_COPR_PROJECT`, e.g. `packit/packit-releases`
 * `PACKIT_COPR_RPMS`, space-separated list of RPMs that were built in Copr
 


### PR DESCRIPTION
Related to https://github.com/packit/packit-service/pull/2494

RELEASE NOTES BEGIN

 Packit now passes PACKIT_TAG_NAME to the Testing Farm run when it's triggered by a release event.

RELEASE NOTES END
