### PR TITLE
Adjust pull-from-upstream docs to non-git upstreams support

### DIFF
--- a/docs/cli/pull-from-upstream.md
+++ b/docs/cli/pull-from-upstream.md
@@ -12,13 +12,13 @@ upstream release. This command is meant to be called from **dist-git repository*
 
 
 ## Requirements
-
-* Upstream git repository on GitHub/GitLab.
-* Upstream release (git tag) where version in spec file is equivalent to
-  the name of the git tag (or `upstream_tag_template` is configured).
 * Packit config file placed in the dist-git repository.
 * Pagure API tokens for Fedora (or CentOS Stream) Dist-git.
 * Valid Fedora (or CentOS Stream) Kerberos ticket.
+* If `upstream_project_url` is configured in Packit config:
+  * Upstream project is expected to be a git repository on GitHub/GitLab.
+  * Upstream release (git tag) where version in spec file is equivalent to
+    the name of the git tag (or `upstream_tag_template` is configured).
 
 
 ## Help

--- a/docs/configuration/actions.md
+++ b/docs/configuration/actions.md
@@ -251,6 +251,8 @@ Related to the `propose-downstream` and `pull-from-upstream` jobs.
 * `PACKIT_UPSTREAM_REPO` — absolute path to cloned upstream git repo (main branch) 
 * `PACKIT_DOWNSTREAM_REPO` — absolute path to cloned downstream git repo (target branch)
 * `PACKIT_PROJECT_VERSION` - version that is being proposed
+* `PACKIT_PWD` - absolute path to the directory where the actions are run; for git upstreams this is the same
+as `PACKIT_UPSTREAM_REPO`
 
 List of actions that provide these environment variables:
 * `post-upstream-clone`

--- a/docs/configuration/downstream/pull_from_upstream.md
+++ b/docs/configuration/downstream/pull_from_upstream.md
@@ -45,7 +45,11 @@ Packit dist-git configuration.
 * Upstream release monitoring is active for the package. [The monitoring
   status](https://docs.fedoraproject.org/en-US/package-maintainers/Upstream_Release_Monitoring/)
   in dist-git should be set to `Monitoring`.
-* [`upstream_project_url`](/docs/configuration#upstream_project_url) pointing to a Git repository is defined in the configuration.
+
+### Optional
+* [`upstream_project_url`](/docs/configuration#upstream_project_url) pointing to a Git repository.
+If this is not configured, no repository will be cloned (no interaction with it will occur), 
+and the [actions](/docs/configuration/actions) will be executed in an arbitrary directory.
 
 ## First setup
 When setting up this job for the first time, please follow the recommended actions from 

--- a/docs/configuration/downstream_configuration_template.md
+++ b/docs/configuration/downstream_configuration_template.md
@@ -17,17 +17,20 @@ and paste the content
 # See the documentation for more information:
 # https://packit.dev/docs/configuration/
 
-# TODO fill in the URL to the upstream Git repo (one that can be passed to anonymous `git clone`)
-upstream_project_url: https://github.com/<upstream-repository>
+# TODO optionally fill in the URL to the upstream Git repo (one that can be passed to anonymous `git clone`)
+# this can be omitted, but in that case there will be no interaction with the upstream repo (no cloning)
+#upstream_project_url: https://github.com/<upstream-repository>
 
 # TODO optionally uncomment and fill in the URL of repository where you want to be notified via issues about errors
 #issue_repository: https://github.com/<my-repo-for-issues>
 
-# TODO unless upstream tags match the version strings, you need to uncomment this and adjust the template to match the upstream tag format
+# TODO uncomment and adjust the template if the upstream tags do not match the version strings.
+# (Only relevant if your upstream project is a git repository (= `upstream_project_url` is set).
 # https://packit.dev/docs/configuration#upstream_tag_template
 #upstream_tag_template: v{version}
 
 # TODO uncomment and adjust if you want Packit to filter upstream tags that should be reacted upon
+# applies only when `upstream_project_url` is configured
 # https://packit.dev/docs/configuration#upstream_tag_include
 # https://packit.dev/docs/configuration#upstream_tag_exclude
 #upstream_tag_include: <python-regex>

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -575,13 +575,15 @@ For the details on how to enable staging instance, please see [the onboarding gu
 (*string*) This field requires a Python regex pattern. It's used with `re.match` to:
 - include tags: When identifying the latest upstream tag, this pattern filters in specific tags.
 - in Packit Service: In `propose_downstream` and `pull_from_upstream` jobs, it determines whether a specific release 
-should trigger a reaction.
+should trigger a reaction. However, for `pull_from_upstream`, it is applied only when the 
+`upstream_project_url` is configured.
 
 #### upstream_tag_exclude
 (*string*) This field requires a Python regex pattern. It's used with `re.match` to:
 - exclude tags: When identifying the latest upstream tag, this pattern omits certain tags.
 - in Packit Service: In `propose_downstream` and `pull_from_upstream` jobs, it determines whether a specific release 
-should trigger a reaction.
+should trigger a reaction. However, for `pull_from_upstream`, it is applied only when the 
+`upstream_project_url` is configured.
 
 #### prerelease_suffix_pattern
 (*string*) This field requires a partial Python regex pattern. It is used to match recognized pre-release suffixes.

--- a/docs/fedora-releases-guide/dist-git-onboarding.md
+++ b/docs/fedora-releases-guide/dist-git-onboarding.md
@@ -74,11 +74,14 @@ as shown below.
 
 If you want to restrict what releases with corresponding tags Packit should react on, 
 you can utilise the configuration options [`upstream_tag_include`](/docs/configuration/#upstream_tag_include) and
-[`upstream_tag_exclude`](/docs/configuration/#upstream_tag_exclude).
+[`upstream_tag_exclude`](/docs/configuration/#upstream_tag_exclude). However, these are currently taken into consideration only when the 
+`upstream_project_url` is configured. In case of omitting it in configuration, you can adjust the releases filtering
+using the `release-monitoring.org` project settings.
 
 :::caution
 
-It is necessary to set the [`upstream_project_url`](/docs/configuration/#upstream_project_url) (upstream project Git repository URL) configuration option. However, upstream tarball URL is taken from the spec file or from [`sources`](/docs/configuration/#sources) (see below).
+Upstream tarball URL is taken from the spec file or from [`sources`](/docs/configuration/#sources) (see below) 
+and not from `upstream_project_url`.
 
 :::
 
@@ -262,7 +265,6 @@ It's quite simple, isn't it?
 
 
 ```yaml
-upstream_project_url: https://github.com/upstream/package
 jobs:
 
 - job: pull_from_upstream

--- a/docs/fedora-releases-guide/index.md
+++ b/docs/fedora-releases-guide/index.md
@@ -131,7 +131,8 @@ jobs:
 The process of releasing a new version starts in the upstream repository by creating a 
 new upstream release. If you want to restrict what releases with corresponding tags Packit should react on, 
 you can utilise the configuration options [`upstream_tag_include`](/docs/configuration/#upstream_tag_include) and
-[`upstream_tag_exclude`](/docs/configuration/#upstream_tag_exclude).
+[`upstream_tag_exclude`](/docs/configuration/#upstream_tag_exclude). However, these are currently taken into consideration only when the 
+`upstream_project_url` is configured with `pull_from_upstream` job or for `propose_downstream` job.
 
 ### Upload archive to lookaside cache
 The upstream archive needs to be downloaded by Packit first and then uploaded to the lookaside cache.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -390,8 +390,7 @@ in [the document](/docs/cli/srpm) dedicated to the `srpm` command.
 
 When you are not allowed or do not want to run packit command from the upstream
 git repository, you can run commands from the cloned dist-git repository in the
-same way as you do from upstream.  Make sure, that you specify the
-`upstream_project_url` in your configuration.
+same way as you do from upstream.  
 
 Is your `packit srpm` finally passing? If not, feel free to [reach out to us](/#contact).
 If yes, let's proceed to the next level.

--- a/posts/pull-from-upstream/index.md
+++ b/posts/pull-from-upstream/index.md
@@ -55,10 +55,11 @@ there is much less delayed).
 ### Packit configuration
 
 To automatically pull the upstream release as a reaction to the bug in Bugzilla, `pull_from_upstream` job
-together with the `upstream_project_url` configuration option, needs to be defined in the default branch
+needs to be defined in the default branch
 (`rawhide`) of the dist-git repository in the Packit configuration file (see
-[our documentation](/docs/configuration/downstream/pull_from_upstream)). The [`upstream_project_url`](/docs/configuration/#upstream_project_url) needs to be a URL
-pointing to a Git repository so that we can do `git` commands on it.
+[our documentation](/docs/configuration/downstream/pull_from_upstream)). The [`upstream_project_url`](/docs/configuration/#upstream_project_url)
+needs to be a URL pointing to a Git repository so that we can do `git` commands on it.
+If not specified, upstream repository is not being cloned.
 
 ## `pull_from_upstream` in action
 


### PR DESCRIPTION
Related to packit/packit-service#2203
