### PR TITLE
Fix the link anchors

### DIFF
--- a/docs/configuration/downstream/pull_from_upstream.md
+++ b/docs/configuration/downstream/pull_from_upstream.md
@@ -78,7 +78,7 @@ Use a repository you maintain as we will create issues about failures here.
 
 :::info
 For how to keep dist-git branches non divergent 
-please see the details [here](/docs/fedora-releases-guide#keeping-dist-git-branches-non-divergent).
+please see the details [here](/docs/fedora-releases-guide#keep-dist-git-branches-non-divergent).
 :::
 
   As branch names you can use the [aliases provided by Packit](/docs/configuration#aliases)

--- a/docs/configuration/upstream/propose_downstream.md
+++ b/docs/configuration/upstream/propose_downstream.md
@@ -57,7 +57,7 @@ configuration specifics, see [the subsection below](#syncing-the-release-to-cent
 
 :::info
 For how to keep dist-git branches non-divergent 
-please see the details [here](/docs/fedora-releases-guide#keeping-dist-git-branches-non-divergent).
+please see the details [here](/docs/fedora-releases-guide#keep-dist-git-branches-non-divergent).
 :::
   
   As branch names you can also use the [aliases provided by Packit](/docs/configuration#aliases)

--- a/docs/fedora-releases-guide/dist-git-onboarding.md
+++ b/docs/fedora-releases-guide/dist-git-onboarding.md
@@ -89,7 +89,7 @@ You can check the other customization options [here](./index.md#customization).
 
 :::info Divergent dist-git branches
 Current default behaviour of the release syncing results in having divergent dist-git branches. If you want to avoid this,
-please see the details [here](/docs/fedora-releases-guide#keeping-dist-git-branches-non-divergent).
+please see the details [here](/docs/fedora-releases-guide#keep-dist-git-branches-non-divergent).
 :::
 
 


### PR DESCRIPTION
A little fix for `Keep dist-git branches non-divergent`.