### PR TITLE
Add docs for using --env within manual trigger

### DIFF
--- a/docs/configuration/upstream/tests.md
+++ b/docs/configuration/upstream/tests.md
@@ -229,7 +229,7 @@ to be triggered without the need for manual specification.
 
 ## Running tests with specific environment variables
 From time to time, you may need to pass specific environment variables to your jobs. 
-To achieve this, you can use the `--env` option, which passes environment variables to Testing Farm.
+To achieve this, you can use the `--env` option in the comment command `/packit test`, which passes environment variables to Testing Farm.
 You can set as many environment variables as you want; you just need to pass `--env `for each one. 
 For example, you can use the following command `/packit test --env MY_ENV=test --env MY_ENV_2=test_2`.
 This command allows you to use `MY_ENV` and `MY_ENV_2` in Testing Farm jobs.

--- a/docs/configuration/upstream/tests.md
+++ b/docs/configuration/upstream/tests.md
@@ -227,6 +227,14 @@ The labels should be in the format of comma-separated string.
 You can also configure [`test_command.default_labels`](/docs/configuration#default_labels) to allow commonly used job combinations
 to be triggered without the need for manual specification.
 
+## Running tests with specific environment variables
+From time to time, you may need to pass specific environment variables to your jobs. 
+To achieve this, you can use the `--env` option, which passes environment variables to Testing Farm.
+You can set as many environment variables as you want; you just need to pass `--env `for each one. 
+For example, you can use the following command `/packit test --env MY_ENV=test --env MY_ENV_2=test_2`.
+This command allows you to use `MY_ENV` and `MY_ENV_2` in Testing Farm jobs.
+You can also unset an environment variable by not setting its value like `/packit test --env MY_ENV=`.
+
 ## Test job statuses
 By default, while test jobs are waiting for their corresponding build jobs to finish,
 their statuses share updates with the build jobs, for example `SRPM build is in progress...`


### PR DESCRIPTION
This PR adds documentation for feature delivered in https://github.com/packit/packit-service/pull/2583

- [x] Update or write new documentation in `packit/packit.dev`.

RELEASE NOTES BEGIN

Packit now supports --env parameters in manual trigger command.

RELEASE NOTES END
