### PR TITLE
Add a blog post for the week 16

### DIFF
--- a/weekly/2025/week-16.md
+++ b/weekly/2025/week-16.md
@@ -1,0 +1,14 @@
+---
+title: Week 16 in Packit
+date: 2025-04-22
+authors: flachman
+tags:
+  - 2025-April
+  - 2025
+  - April
+---
+
+## Week 16 (April 16th – April 22nd)
+
+- The `--resultdir` argument in `build_in_mock` now defaults to the current directory (`"."`), preventing loss of build artifacts when not explicitly set. ([packit#2567](https://github.com/packit/packit/pull/2567))
+- `tf_extra_params` should now be included when submitting the automatic upstream installability check to the Testing Farm. ([packit-service#2779](https://github.com/packit/packit-service/pull/2779))


### PR DESCRIPTION
Not sure why the release notes from https://github.com/packit/packit-service/pull/2779 weren't picked by the script... :thinking: 