### PR TITLE
Add documentation regarding new functionality of packit init

### DIFF
--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -7,7 +7,13 @@ sidebar_position: 3
 
 Initiate a repository to start using packit. By default this command adds
 `.packit.yaml` config file to the git repository in the current working
-directory.  
+directory.
+
+If a `.pre-commit-config.yaml` file is found at the root of the git repository, `init` will add a pre-commit hook, which automatically runs `packit config validate` to check the validity of `.packit.yaml` upon pre-commit. Before adding this hook, `init` also checks for the presence of a `.git` repo. This behavior can be disabled using the `--without-precommit` flag.
+
+In case `.pre-commit-config.yaml` is not found at the root of the repository, this behavior is skipped and can be forced using the `--force-precommit` flag. Please note that the
+two listed flags `--without-precommit` and `--force-precommit` are mutually exclusive.
+
 If a spec file is found in the git repository, `init` will set
 [specfile_path](/docs/configuration/#specfile_path) to point to it in `.packit.yaml`.
 Otherwise, `specfile_path` is set to `<the name of the repository>.spec`.
@@ -25,5 +31,7 @@ initialize a [source-git repo](/source-git).
       source-git repo.
 
     Options:
-      -f, --force  Reset config to default if already exists.
-      -h, --help   Show this message and exit.
+      --force-precommit    Automatically create an empty pre-commit configuration file if missing.
+      --without-precommit  Skip adding pre-commit hook to pre-commit configuration file.
+      -f, --force          Reset config to default if already exists.
+      -h, --help           Show this message and exit.


### PR DESCRIPTION
Documentation now describes new requirements connected to the functionality of `packit init` that automatically adds a packit-specific pre-commit hook that validates `.packit.yaml` to the user's pre-commit onfiguration file (skipped if pre-commit configuration file is not present). Two new flags were also edit to modify this behavior:

`--force-precommit` : initializes an empty pre-commit onfiguration file if missing and adds aforementioned pre-commit hook
`--without-precommit` : skips this pre-commit-related behavior


Related to [#2641](https://github.com/packit/packit/pull/2641)

Merge at the same time as [#2641](https://github.com/packit/packit/pull/2641)
