### PR TITLE
Add help commands to documentation

### DIFF
--- a/docs/retriggering.md
+++ b/docs/retriggering.md
@@ -15,6 +15,11 @@ In case your project is a monorepository containing multiple packages, it is pos
 
 Do not use the `--package` argument in a project that is not a monorepository as that will result in no jobs being triggered. Also make sure not to switch the order of arguments as the `--package` argument has to be specified first in order to work.
 
+### help
+Packit is able to provide a help message summarizing all available commands and options:
+
+    /packit help
+
 ### copr_build
 For retriggering the [`copr_build`](/docs/configuration/upstream/copr_build) jobs, Packit is able to trigger new builds based on a pull request comment:
 

--- a/fedora-ci/retriggering.md
+++ b/fedora-ci/retriggering.md
@@ -5,6 +5,12 @@ sidebar_position: 2
 
 You can retrigger CI jobs in dist-git pull requests by posting comments that include the appropriate `/packit-ci` commands, as outlined below.
 
+## Help
+
+Packit is able to provide a help message summarizing all available commands and options:
+
+    /packit-ci help
+
 ## Scratch builds
 
 To retrigger a scratch build, add the following comment to the pull request:


### PR DESCRIPTION
Add information regarding the `/packit help` and `/packit-ci help` commands, which can be used in comments in PRs and issues, to the documentation.

Merge after [#2853](https://github.com/packit/packit-service/pull/2853)
