### PR TITLE
Add link to source of this website

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -309,7 +309,7 @@ const config = {
             ],
           },
         ],
-        copyright: `Copyright © ${new Date().getFullYear()} Packit is a Red Hat sponsored free software project. Built with Docusaurus.`,
+        copyright: `Copyright © ${new Date().getFullYear()} Packit is a Red Hat sponsored free software project. Built with Docusaurus. <a href="https://github.com/packit/packit.dev">Source of this page</a>.`,
       },
       prism: {
         theme: lightCodeTheme,


### PR DESCRIPTION
A user asked me where to file issues with this website. There is no direct link. There is only link to Packit organisation, that contains 50+ repositories. This should make reports and contributions more straightforward.
