### PR TITLE
fix(blog): add dates to the blog post

### DIFF
--- a/posts/code-review/index.md
+++ b/posts/code-review/index.md
@@ -1,6 +1,7 @@
 ---
 title: Our experience with AI-based code review
 authors: ttomecek
+date: 2026-02-24
 tags:
   - AI
   - code-review

--- a/posts/comparing-frontier-models-june2026/index.mdx
+++ b/posts/comparing-frontier-models-june2026/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Comparing frontier Claude models for our AI workflows (June 2026)
 authors: ttomecek
+date: 2026-06-09
 tags:
   - AI
   - automation


### PR DESCRIPTION
As I have noticed when opening the blog post about release syncing in Packit from Nikola, when you don't specify the date the blogs get assigned the date during the build.

Therefore these two blog posts are kept at the top of the posts.

Add the dates of merging to fix this issue.

Cc @TomasTomecek I don’t want to steal your limelight, but it’s time for your blog post from February, to sink down 😈 