### PR TITLE
docs: clarify that a job trigger accepts a single value

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -76,6 +76,9 @@ files_to_sync:
 (*list of dicts*) A list of job definitions for Packit Service: see
 [Packit Service jobs configuration](configuration/jobs) for details.
 
+The `trigger` key of a job accepts exactly one value — it is not a list, and
+multiple triggers cannot be combined in one job.
+
 ### Package-specific keys
 #### paths
 (*list*) List of relative paths in the upstream repository, which should be considered for the particular package


### PR DESCRIPTION
Adds an explicit note to the `jobs` section of `docs/configuration/index.md`
stating that a job's `trigger` key accepts exactly one value and cannot be a
list or combination of multiple triggers.

Closes #1054

Prepared with AI assistance (Kimi K2.7 Code), human-reviewed before submission.
