### PR TITLE
Fix dangling ToC anchors on dist-git-onboarding

### DIFF
--- a/docs/fedora-releases-guide/dist-git-onboarding.md
+++ b/docs/fedora-releases-guide/dist-git-onboarding.md
@@ -5,8 +5,8 @@ sidebar_position: 6
 # Dist-git repository onboarding
 ## Table of contents
 - [Setup](#setup)
-  - [1. Configuration file](#configuration-file)
-  - [2. Monitoring](#monitoring-of-the-package)
+  - [1. Configuration file](#1-configuration-file)
+  - [2. Monitoring](#2-monitoring-of-the-package)
   - [How to try that for real](#how-to-try-that-for-real)
 - [UI](#ui)
 - [Retriggering](#retriggering)


### PR DESCRIPTION
## Summary

Fixes #1087.

The hand-written table of contents on `docs/fedora-releases-guide/dist-git-onboarding.md` links `#configuration-file` and `#monitoring-of-the-package`, but the actual headings are **"1. Configuration file"** and **"2. Monitoring of the package"** — Docusaurus slugs those *with* the leading number, so the real anchors are `#1-configuration-file` and `#2-monitoring-of-the-package` (verified against the rendered page: the `id=` attributes on packit.dev are `1-configuration-file` / `2-monitoring-of-the-package`). The two ToC entries now point at the real anchors.

The other five ToC entries resolve correctly and are untouched.

## AI assistance disclosure

This PR was prepared with AI assistance (Claude); the anchor IDs were verified against the live rendered page before the change.