### PR TITLE
Document that job-level actions replace the whole top-level actions mapping

### DIFF
--- a/docs/configuration/actions.md
+++ b/docs/configuration/actions.md
@@ -39,8 +39,34 @@ e.g. cloning an upstream repo.
 :::caution
 
 Like other keys, the `actions` can be defined on the top, package or job level.
-Be aware that when overriding, the whole `action` mapping is replaced
-instead of merging.
+Be aware that when overriding, the whole `actions` mapping is replaced
+instead of merged per action. In other words, a job that defines its own
+`actions` does **not** inherit any of the top-level actions — only the ones it
+lists itself are applied.
+
+For example:
+
+```yaml
+actions:
+  post-upstream-clone:
+    - echo "top-level clone"
+  create-archive:
+    - echo "top-level archive"
+  fix-spec-file:
+    - echo "top-level spec fix"
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    actions:
+      create-archive:
+        - echo "job archive"
+```
+
+For the `copr_build` job above, only `create-archive` runs (executing
+`echo "job archive"`). The top-level `post-upstream-clone` and `fix-spec-file`
+actions are **not** applied to this job, because its `actions` mapping replaces
+the top-level one as a whole rather than being merged into it.
 
 If you want to reduce duplications, you can use the following YAML syntax to do this:
 


### PR DESCRIPTION
Fixes #443.

The existing `:::caution` on `docs/configuration/actions.md` stated the replacement abstractly; #443 asked for the concrete answer to "is it whole-section replacement or per-key merge?". This expands that same admonition (no restructuring) with a worked example mirroring the issue — three top-level actions, a `copr_build` job redefining only `create-archive` — and states explicitly that only the job's own actions run.

**The claim is verified three ways against packit source**, not taken from the issue title:
- Schema code: `JobConfigSchema` has no `actions` field, and `rearrange_jobs` shallow-merges the job dict over the package config (`packit/schema.py:884`) — the `actions` key is overwritten wholesale.
- Upstream test: `tests/unit/config/test_package_config.py:1375-1419` asserts a job's `actions` drops unlisted top-level actions.
- Runtime: loaded exactly the example config through `PackageConfig.get_from_dict` — the job ends up with `{create-archive}` only.

Also fixes the pre-existing `action` → `actions` typo in the retained sentence.

Gate: `make import` + `yarn build` (the actual PR gate per `.github/workflows/test-deploy.yml`) — production build succeeds.

## AI assistance disclosure

Researched and written with AI assistance (Claude); the documented behavior was verified against packit source, an upstream test, and a live schema-load before opening.