### PR TITLE
docs: clarify that job-level actions replace top-level actions as a whole

### DIFF
--- a/docs/configuration/actions.md
+++ b/docs/configuration/actions.md
@@ -39,8 +39,32 @@ e.g. cloning an upstream repo.
 :::caution
 
 Like other keys, the `actions` can be defined on the top, package or job level.
-Be aware that when overriding, the whole `action` mapping is replaced
-instead of merging.
+Be aware that when overriding, the whole `actions` mapping is replaced
+instead of merging per action.
+
+For example, with `actions` defined both at the top level and in a job:
+
+```yaml
+actions:
+  create-archive:
+    - "make archive"
+  fix-spec-file:
+    - "make fix-spec-file"
+  post-upstream-clone:
+    - "make post-upstream-clone"
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    actions:
+      create-archive:
+        - "make custom-archive"
+```
+
+when the `copr_build` job is triggered, only the actions listed in the job are
+effective, i.e. just `create-archive` (running the job's own commands). The
+top-level `fix-spec-file` and `post-upstream-clone` are **not** inherited and
+will **not** run. If you need them, repeat them in the job's `actions` mapping.
 
 If you want to reduce duplications, you can use the following YAML syntax to do this:
 

--- a/docs/configuration/jobs.md
+++ b/docs/configuration/jobs.md
@@ -80,7 +80,10 @@ jobs:
 
 Do not forget that you can also define common Packit config options at the
 top level (such as `targets` or `actions`) and only override them when
-needed in the `jobs` or `packages` section.
+needed in the `jobs` or `packages` section. Note that overriding replaces the
+whole value, not individual keys — for `actions` this means a job's `actions`
+mapping [replaces the top-level one as a whole](/docs/configuration/actions),
+rather than being merged per action.
 
 For more complex structures it can be useful to have yaml-anchors that are ignored,
 in which case you can use the top-level `_` key, for example:


### PR DESCRIPTION
Fixes #443.

The behavior was verified against the packit source before documenting, both statically and dynamically:

- **Statically**: `actions` is a `CommonConfigSchema` field, not a `JobConfigSchema` field, so in `rearrange_jobs` it stays inside the raw job dict; the effective package config is built with a shallow dict union (`v | job`, packit `schema.py:882-885` and the sibling branches), which replaces the value at the `actions` key **wholesale** — no per-action merge.
- **Dynamically**: loading the issue's exact YAML shape through packit's own `PackageConfigSchema().load()` yields a job whose effective actions are only `create-archive`; the top-level `fix-spec-file` / `post-upstream-clone` are absent.

So the issue title's guess is confirmed: job-level `actions` replace the top-level mapping as a whole.

Changes:

- `docs/configuration/actions.md` — the existing caution already stated the replace semantics abstractly; this adds the concrete example the issue asks for (the issue's own YAML shape, with a plain statement of which actions actually run when the job triggers), and fixes `action` → `actions` in the existing sentence.
- `docs/configuration/jobs.md` — the "define common options at the top level and only override when needed" sentence is where the merge assumption naturally forms; added one clause + a cross-link to the actions caution.

Build gate: the CI pipeline's steps (`make import`, `yarn install --frozen-lockfile`, `yarn build`) pass locally on this branch — `[SUCCESS] Generated static files`, cross-link resolves.

*Disclosure: this contribution was made with AI assistance (Claude); the documented behavior was proven against the packit source and parser rather than assumed.*
