### PR TITLE
Add blog post for week 35

### DIFF
--- a/weekly/2026/week-35.md
+++ b/weekly/2026/week-35.md
@@ -1,0 +1,13 @@
+---
+title: Week 35 in Packit
+date: 2026-09-01
+authors: mmassari
+tags:
+  - 2026-August
+  - 2026
+  - August
+---
+
+## Week 35 (August 26th – September 1st)
+
+- Packit Service now respects job identifiers when multiple base builds exist for the same branch with different configurations, ensuring OpenScanHub scans compare against the correct matching base build. ([packit-service#3172](https://github.com/packit/packit-service/pull/3172))


### PR DESCRIPTION
## Summary

- Adds weekly blog post for week 35 (August 26th – September 1st)

## Changes

- Koji side-tag builds: Fixed parsing of Koji build completion events for builds using side-tags
- OpenScanHub differential scans: Improved accuracy when selecting base builds for differential scans